### PR TITLE
Require http tokens for metadata (IMDSv2)

### DIFF
--- a/terraform/nextflow-launch-templates.tf
+++ b/terraform/nextflow-launch-templates.tf
@@ -13,5 +13,11 @@ resource "aws_launch_template" "nf_lt_standard" {
       delete_on_termination = true
     }
   }
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags = "enabled"
+  }
   update_default_version = true
 }


### PR DESCRIPTION
Right now, EC2 instances have been created with IMSDv2 as optional. We want to enforce that. Because we're using an Amazon Linux 2023 image, I would have expected us to get that without any intervention, but that is not what the console reports. Here's a link to the documentation I referenced: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#metadata-options