### PR TITLE
Use nextflow-specific key

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+kms = "kms"

--- a/config/profile_wave.config
+++ b/config/profile_wave.config
@@ -1,6 +1,6 @@
 // profile for wave and fusion filesystem enabled pipeline
 
-workDir = 's3://nextflow-ccdl-data/work'
+workDir = 's3://openscpca-nf-data/work'
 docker.enabled = true
 wave.enabled = true
 fusion.enabled = true
@@ -11,12 +11,12 @@ aws{
     maxTransferAttempts = 3
     maxSpotAttempts = 2
   }
-  region = 'us-east-1'
+  region = 'us-east-2'
 }
 
 
 process{
   executor = 'awsbatch'
   scratch = false
-  queue = 'nextflow-batch-default-queue'
+  queue = 'openscpca-nf-batch-default-queue'
 }

--- a/config/profile_wave.config
+++ b/config/profile_wave.config
@@ -18,5 +18,5 @@ aws{
 process{
   executor = 'awsbatch'
   scratch = false
-  queue = 'openscpca-nf-batch-default-queue'
+  queue = 'openscpca-nf-batch-priority-queue'
 }

--- a/main.nf
+++ b/main.nf
@@ -28,8 +28,8 @@ if (param_error) {
 workflow {
   example()
   // project channel of [project_id, project_path]
-  project_ch = Channel.fromPath(Utils.getProjectPaths(release_dir))
-    .map{[it.name, it]} // name is the directory name, which will be SCPCP000000 format
+  // project_ch = Channel.fromPath(Utils.getProjectPaths(release_dir))
+  //   .map{[it.name, it]} // name is the directory name, which will be SCPCP000000 format
 
-  simulate_sce(project_ch)
+  // simulate_sce(project_ch)
 }

--- a/terraform/nextflow-batch.tf
+++ b/terraform/nextflow-batch.tf
@@ -16,6 +16,6 @@ resource "aws_batch_job_queue" "nf_priority_queue" {
   priority = 1
   compute_environment_order {
     order               = 1
-    compute_environment = aws_batch_compute_environment.nf_spot.arn
+    compute_environment = aws_batch_compute_environment.nf_ondemand.arn
   }
 }

--- a/terraform/nextflow-buckets.tf
+++ b/terraform/nextflow-buckets.tf
@@ -15,7 +15,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "nf_work_bucket" {
   rule {
     apply_server_side_encryption_by_default {
       # workload-analysis-researcher-s3 key
-      kms_master_key_id = "arn:aws:kms:us-east-2:992382809252:key/851995f3-26b6-48c1-9d61-c32dd7a8ee83"
+      kms_master_key_id = aws_kms_key.nf_work_key.arn
       sse_algorithm     = "aws:kms"
     }
   }

--- a/terraform/nextflow-compute.tf
+++ b/terraform/nextflow-compute.tf
@@ -1,6 +1,6 @@
 # This file creates the compute environments used by the default and priority queues
-# The default environment is a 100 vCPU spot cluster
-# Priority environment is a 20 vCPU on demand cluster
+# The default environment is a 1024 vCPU spot cluster
+# Priority environment is a 256 vCPU on demand cluster
 
 resource "aws_iam_instance_profile" "nf_ecs_instance_role" {
   name = "openscpca-nf-ecs-instance-role"
@@ -22,7 +22,7 @@ resource "aws_batch_compute_environment" "nf_spot" {
     ]
     allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
     spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
-    bid_percentage      = 100
+    bid_percentage      = 60
     max_vcpus           = 1024
     min_vcpus           = 0
     # standard launch template

--- a/terraform/nextflow-kms.tf
+++ b/terraform/nextflow-kms.tf
@@ -89,7 +89,7 @@ resource "aws_kms_key_policy" "nf_work_key" {
             aws_iam_role.nf_spotfleet_role.arn
           ]
         },
-        Action   = "km:CreateGrant"
+        Action   = "kms:CreateGrant"
         Resource = "*"
         Condition = {
           Bool = {

--- a/terraform/nextflow-kms.tf
+++ b/terraform/nextflow-kms.tf
@@ -57,23 +57,6 @@ resource "aws_kms_key_policy" "nf_work_key" {
         ]
         Resource = "*"
       },
-      {
-        Sid    = "AllowCCDLMembersAccess"
-        Effect = "Allow"
-        Principal = {
-          AWS = [
-            "arn:aws:iam::589864003899:user/ally-hawkins",
-            "arn:aws:iam::589864003899:user/josh",
-            "arn:aws:iam::589864003899:user/stephanie",
-            "arn:aws:iam::589864003899:user/jaclyntaroni"
-          ]
-        }
-        Action = [
-          "kms:GenerateDataKey",
-          "kms:Decrypt"
-        ]
-        Resource = aws_kms_key.nf_work_key.arn
-      },
       # Autoscaling role policies based on https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html
       {
         Sid    = "AllowServiceRole"

--- a/terraform/nextflow-kms.tf
+++ b/terraform/nextflow-kms.tf
@@ -17,7 +17,7 @@ resource "aws_kms_key_policy" "nf_work_key" {
         Sid    = "EnableUserPermissions"
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::992382809252:root"
+          AWS = "arn:aws:iam::${local.account_id}:root"
         }
         Action   = "kms:*"
         Resource = "*"
@@ -26,7 +26,7 @@ resource "aws_kms_key_policy" "nf_work_key" {
         Sid    = "AllowAdministration"
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::992382809252:root"
+          AWS = "arn:aws:iam::${local.account_id}:root"
         }
         Action = [
           "kms:Create*",
@@ -49,7 +49,7 @@ resource "aws_kms_key_policy" "nf_work_key" {
         Sid    = "AllowUse"
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::992382809252:root"
+          AWS = "arn:aws:iam::${local.account_id}:root"
         }
         Action = [
           "kms:DescribeKey",
@@ -63,9 +63,10 @@ resource "aws_kms_key_policy" "nf_work_key" {
         Effect = "Allow"
         Principal = {
           AWS = [
-            "arn:aws:iam::992382809252:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+            "arn:aws:iam::${local.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
             aws_iam_role.nf_batch_role.arn,
-            aws_iam_role.nf_ecs_role.arn
+            aws_iam_role.nf_ecs_role.arn,
+            aws_iam_role.nf_spotfleet_role.arn
           ]
         },
         Action = [
@@ -81,7 +82,12 @@ resource "aws_kms_key_policy" "nf_work_key" {
         Sid    = "AllowServiceRolePersistentAttachment"
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::992382809252:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+          AWS = [
+            "arn:aws:iam::${local.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+            aws_iam_role.nf_batch_role.arn,
+            aws_iam_role.nf_ecs_role.arn,
+            aws_iam_role.nf_spotfleet_role.arn
+          ]
         },
         Action   = "km:CreateGrant"
         Resource = "*"

--- a/terraform/nextflow-kms.tf
+++ b/terraform/nextflow-kms.tf
@@ -1,0 +1,57 @@
+resource "aws_kms_key" "nf_work_key" {
+  description = "OpenScPCA Nextflow work bucket key"
+}
+
+resource "aws_kms_alias" "nf_work_key" {
+  name          = "alias/openscpca-nf-work"
+  target_key_id = aws_kms_key.nf_work_key.key_id
+}
+
+resource "aws_kms_key_policy" "nf_work_key" {
+  key_id = aws_kms_key.nf_work_key.id
+  policy = jsonencode({
+    Version = "2008-10-17"
+    Id      = "example"
+    Statement = [
+      {
+        Sid    = "EnableUserPermissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::992382809252:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      # Autoscaling role policies based on https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html
+      {
+        Sid    = "AllowServiceRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::992382809252:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+        },
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ],
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowServiceRolePersistentAttachment"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::992382809252:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+        },
+        Action   = "km:CreateGrant"
+        Resource = "*"
+        Condition = {
+          Bool = {
+            "kms:GrantIsForAWSResource" = "true"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/nextflow-kms.tf
+++ b/terraform/nextflow-kms.tf
@@ -10,8 +10,8 @@ resource "aws_kms_alias" "nf_work_key" {
 resource "aws_kms_key_policy" "nf_work_key" {
   key_id = aws_kms_key.nf_work_key.id
   policy = jsonencode({
-    Version = "2008-10-17"
-    Id      = "example"
+    Version = "2012-10-17"
+    Id      = "openscpca-nf-work-key-policy"
     Statement = [
       {
         Sid    = "EnableUserPermissions"
@@ -22,12 +22,68 @@ resource "aws_kms_key_policy" "nf_work_key" {
         Action   = "kms:*"
         Resource = "*"
       },
+      {
+        Sid    = "AllowAdministration"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::992382809252:root"
+        }
+        Action = [
+          "kms:Create*",
+          "kms:Describe*",
+          "kms:Enable*",
+          "kms:List*",
+          "kms:Put*",
+          "kms:Update*",
+          "kms:Revoke*",
+          "kms:Disable*",
+          "kms:Get*",
+          "kms:Delete*",
+          "kms:GenerateDataKey*",
+          "kms:ScheduleKeyDeletion",
+          "kms:CancelKeyDeletion"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowUse"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::992382809252:root"
+        }
+        Action = [
+          "kms:DescribeKey",
+          "kms:Decrypt"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowCCDLMembersAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = [
+            "arn:aws:iam::589864003899:user/ally-hawkins",
+            "arn:aws:iam::589864003899:user/josh",
+            "arn:aws:iam::589864003899:user/stephanie",
+            "arn:aws:iam::589864003899:user/jaclyntaroni"
+          ]
+        }
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt"
+        ]
+        Resource = aws_kms_key.nf_work_key.arn
+      },
       # Autoscaling role policies based on https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html
       {
         Sid    = "AllowServiceRole"
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::992382809252:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+          AWS = [
+            "arn:aws:iam::992382809252:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+            aws_iam_role.nf_batch_role.arn,
+            aws_iam_role.nf_ecs_role.arn
+          ]
         },
         Action = [
           "kms:Encrypt",

--- a/terraform/nextflow-launch-templates.tf
+++ b/terraform/nextflow-launch-templates.tf
@@ -2,14 +2,14 @@ resource "aws_launch_template" "nf_lt_standard" {
   name = "openscpca-nf-standard"
   # the AMI used is the Amazon ECS-optimized Amazon Linux 2023 AMI
   # id determined with `aws ssm get-parameters --names /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended --region us-east-2`
-  image_id = "ami-06adbea8e9d7cae16"
+  image_id = "ami-097abe41711c05939"
   block_device_mappings {
     device_name = "/dev/xvda"
     ebs {
       volume_size           = 128 #GiB
       volume_type           = "gp3"
       encrypted             = true
-      kms_key_id            = "arn:aws:kms:us-east-2:992382809252:key/851995f3-26b6-48c1-9d61-c32dd7a8ee83"
+      km_key_id            = "arn:aws:km:us-east-2:992382809252:key/851995f3-26b6-48c1-9d61-c32dd7a8ee83"
       delete_on_termination = true
     }
   }

--- a/terraform/nextflow-launch-templates.tf
+++ b/terraform/nextflow-launch-templates.tf
@@ -9,7 +9,7 @@ resource "aws_launch_template" "nf_lt_standard" {
       volume_size           = 128 #GiB
       volume_type           = "gp3"
       encrypted             = true
-      km_key_id            = "arn:aws:km:us-east-2:992382809252:key/851995f3-26b6-48c1-9d61-c32dd7a8ee83"
+      kms_key_id            = aws_kms_key.nf_work_key.arn
       delete_on_termination = true
     }
   }

--- a/terraform/nextflow-policies.tf
+++ b/terraform/nextflow-policies.tf
@@ -13,7 +13,6 @@ resource "aws_iam_policy" "nf_readwrite_S3" {
         Sid    = "ReadWriteWorkResults"
         Effect = "Allow",
         Action = [
-          "s3:HeadBucket",
           "s3:ListBucket",
           "s3:*Object"
         ]
@@ -21,7 +20,9 @@ resource "aws_iam_policy" "nf_readwrite_S3" {
           aws_s3_bucket.nf_work_bucket.arn,
           "${aws_s3_bucket.nf_work_bucket.arn}/*",
           "arn:aws:s3:::openscpca-nf-workflow-results",
-          "arn:aws:s3:::openscpca-nf-workflow-results/*"
+          "arn:aws:s3:::openscpca-nf-workflow-results/*",
+          "arn:aws:s3:::openscpca-temp-simdata",
+          "arn:aws:s3:::openscpca-temp-simdata/*"
         ]
       }
     ]
@@ -39,9 +40,9 @@ resource "aws_iam_policy" "nf_read_S3" {
         Sid    = "ReleaseBucketReadAccess"
         Effect = "Allow"
         Action = [
+          "s3:ListBucket",
           "s3:HeadObject",
-          "s3:GetObject",
-          "s3:ListBucket"
+          "s3:GetObject"
         ]
         Resource = [
           "arn:aws:s3:::analysis-s3-992382809252-us-east-2", # current data release bucket

--- a/terraform/nextflow-policies.tf
+++ b/terraform/nextflow-policies.tf
@@ -11,10 +11,33 @@ resource "aws_iam_policy" "nf_readwrite_S3" {
     Statement = [
       {
         Sid    = "ReadWriteWorkResults"
-        Effect = "Allow",
+        Effect = "Allow"
         Action = [
-          "s3:ListBucket",
-          "s3:*Object"
+          "s3:GetBucket*",
+          "s3:ListBucket*",
+          "s3:PutBucket*",
+          "s3:GetObject*",
+          "s3:PutObject*",
+          "s3:DeleteObject*",
+          "s3:ReplicateObject",
+          "s3:RestoreObject",
+          "s3:ListMultipartUploadParts",
+          "s3:AbortMultipartUpload",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetAnalyticsConfiguration",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetInventoryConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetMetricsConfiguration",
+          "s3:PutAccelerateConfiguration",
+          "s3:PutAnalyticsConfiguration",
+          "s3:PutEncryptionConfiguration",
+          "s3:PutInventoryConfiguration",
+          "s3:PutLifecycleConfiguration",
+          "s3:PutMetricsConfiguration",
+          "s3:PutReplicationConfiguration",
+          "s3:ReplicateDelete",
+          "s3:ReplicateTags"
         ]
         Resource = [
           aws_s3_bucket.nf_work_bucket.arn,
@@ -40,16 +63,68 @@ resource "aws_iam_policy" "nf_read_S3" {
         Sid    = "ReleaseBucketReadAccess"
         Effect = "Allow"
         Action = [
-          "s3:ListBucket",
+          "s3:GetBucket*",
+          "s3:ListBucket*",
+          "s3:GetObject*",
           "s3:HeadObject",
-          "s3:GetObject"
+          "s3:DescribeJob",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetAccessPointPolicy*",
+          "s3:GetAnalyticsConfiguration",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetInventoryConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetMetricsConfiguration",
+          "s3:GetReplicationConfiguration"
         ]
         Resource = [
           "arn:aws:s3:::analysis-s3-992382809252-us-east-2", # current data release bucket
           "arn:aws:s3:::analysis-s3-992382809252-us-east-2/*",
           "arn:aws:s3:::openscpca-data-release", # data release bucket
-          "arn:aws:s3:::openscpca-data-release/*"
+          "arn:aws:s3:::openscpca-data-release/*",
+          "arn:aws:s3:*:*:accesspoint/*",
+          "arn:aws:s3:*:*:job/*"
         ]
+      },
+      {
+        Sid    = "BucketListAccess"
+        Effect = "Allow"
+        Action = [
+          "s3:GetAccountPublicAccessBlock",
+          "s3:GetAccountPublicAccessBlock",
+          "s3:ListAllMyBuckets",
+          "s3:ListAccessPoints",
+          "s3:ListJobs"
+        ]
+        Resource = [
+          "*"
+        ]
+      }
+    ]
+  })
+}
+
+
+resource "aws_iam_policy" "nf_manage_ebs" {
+  name        = "openscpca-nf-manage-ebs"
+  description = "A policy that allows to manage (attach/create/delete) EBS volumes."
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:AttachVolume",
+          "ec2:DescribeVolumeStatus",
+          "ec2:DescribeVolumes",
+          "ec2:DescribeTags",
+          "ec2:ModifyInstanceAttribute",
+          "ec2:DescribeVolumeAttribute",
+          "ec2:CreateVolume",
+          "ec2:DeleteVolume",
+          "ec2:CreateTags"
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/terraform/nextflow-policies.tf
+++ b/terraform/nextflow-policies.tf
@@ -3,7 +3,7 @@
 
 # S3 Group policies taken from AWS Nextflow batch setup
 
-# This policy allows read and write access to specific buckets for nextflow processing and output
+# This policy allows read and write access to specific buckets for nextflow processing
 resource "aws_iam_policy" "nf_readwrite_S3" {
   name = "openscpca-nf-readwrite-s3"
   policy = jsonencode({
@@ -47,20 +47,30 @@ resource "aws_iam_policy" "nf_readwrite_S3" {
           "arn:aws:s3:::openscpca-temp-simdata",
           "arn:aws:s3:::openscpca-temp-simdata/*"
         ]
+        # },
+        # {
+        #   Effect = "Allow",
+        #   Action = [
+        #     "s3:GetAccountPublicAccessBlock",
+        #     "s3:ListAllMyBuckets",
+        #     "s3:ListAccessPoints",
+        #     "s3:HeadBucket"
+        #   ]
+        #   Resource = "*"
       }
     ]
   })
 }
 
 
-# This policy gives read access to S3 buckets used for nextflow inputs
+# This policy gives read access to S3 buckets, used for nextflow inputs
 resource "aws_iam_policy" "nf_read_S3" {
   name = "openscpca-nf-read-s3"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "ReleaseBucketReadAccess"
+        Sid    = "BucketReadAccess"
         Effect = "Allow"
         Action = [
           "s3:GetBucket*",

--- a/terraform/nextflow-policies.tf
+++ b/terraform/nextflow-policies.tf
@@ -88,8 +88,6 @@ resource "aws_iam_policy" "nf_read_S3" {
           "s3:GetReplicationConfiguration"
         ]
         Resource = [
-          "arn:aws:s3:::analysis-s3-992382809252-us-east-2", # current data release bucket
-          "arn:aws:s3:::analysis-s3-992382809252-us-east-2/*",
           "arn:aws:s3:::openscpca-data-release", # data release bucket
           "arn:aws:s3:::openscpca-data-release/*",
           "arn:aws:s3:*:*:accesspoint/*",

--- a/terraform/nextflow-roles.tf
+++ b/terraform/nextflow-roles.tf
@@ -30,7 +30,7 @@ resource "aws_iam_role_policy_attachment" "nf_batch_full_access" {
   policy_arn = "arn:aws:iam::aws:policy/AWSBatchFullAccess"
 }
 
-resource "aws_iam_role_policy_attachment" "batch_km" {
+resource "aws_iam_role_policy_attachment" "batch_kms" {
   role       = aws_iam_role.nf_batch_role.name
   policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
 }
@@ -72,7 +72,7 @@ resource "aws_iam_role_policy_attachment" "ecs_auto_scale_ebs" {
   policy_arn = aws_iam_policy.nf_manage_ebs.arn
 }
 
-resource "aws_iam_role_policy_attachment" "ecs_km" {
+resource "aws_iam_role_policy_attachment" "ecs_kms" {
   role       = aws_iam_role.nf_ecs_role.name
   policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
 }
@@ -106,7 +106,7 @@ resource "aws_iam_role_policy_attachment" "nf_spotfleet_autoscale" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetAutoscaleRole"
 }
 
-resource "aws_iam_role_policy_attachment" "nf_spotfleet_km" {
+resource "aws_iam_role_policy_attachment" "nf_spotfleet_kms" {
   role       = aws_iam_role.nf_spotfleet_role.name
   policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
 }

--- a/terraform/nextflow-roles.tf
+++ b/terraform/nextflow-roles.tf
@@ -25,7 +25,12 @@ resource "aws_iam_role_policy_attachment" "nf_batch_role" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
 }
 
-resource "aws_iam_role_policy_attachment" "batch_kms" {
+resource "aws_iam_role_policy_attachment" "nf_batch_full_access" {
+  role       = aws_iam_role.nf_batch_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSBatchFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "batch_km" {
   role       = aws_iam_role.nf_batch_role.name
   policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
 }
@@ -62,7 +67,12 @@ resource "aws_iam_role_policy_attachment" "ecs_read_s3" {
   policy_arn = aws_iam_policy.nf_read_S3.arn
 }
 
-resource "aws_iam_role_policy_attachment" "ecs_kms" {
+resource "aws_iam_role_policy_attachment" "ecs_auto_scale_ebs" {
+  role       = aws_iam_role.nf_ecs_role.name
+  policy_arn = aws_iam_policy.nf_manage_ebs.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_km" {
   role       = aws_iam_role.nf_ecs_role.name
   policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
 }
@@ -74,7 +84,8 @@ resource "aws_iam_role" "nf_spotfleet_role" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
-      { Action = "sts:AssumeRole",
+      {
+        Action = "sts:AssumeRole",
         Effect = "Allow",
         Principal = {
           Service = "spotfleet.amazonaws.com"
@@ -83,6 +94,7 @@ resource "aws_iam_role" "nf_spotfleet_role" {
     ]
   })
 }
+
 
 resource "aws_iam_role_policy_attachment" "nf_spotfleet_tagging" {
   role       = aws_iam_role.nf_spotfleet_role.name
@@ -94,7 +106,7 @@ resource "aws_iam_role_policy_attachment" "nf_spotfleet_autoscale" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetAutoscaleRole"
 }
 
-resource "aws_iam_role_policy_attachment" "nf_spotfleet_kms" {
+resource "aws_iam_role_policy_attachment" "nf_spotfleet_km" {
   role       = aws_iam_role.nf_spotfleet_role.name
   policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
 }

--- a/terraform/nextflow-roles.tf
+++ b/terraform/nextflow-roles.tf
@@ -25,6 +25,10 @@ resource "aws_iam_role_policy_attachment" "nf_batch_role" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
 }
 
+resource "aws_iam_role_policy_attachment" "batch_kms" {
+  role       = aws_iam_role.nf_batch_role.name
+  policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
+}
 
 ### ECS Role
 resource "aws_iam_role" "nf_ecs_role" {
@@ -58,6 +62,12 @@ resource "aws_iam_role_policy_attachment" "ecs_read_s3" {
   policy_arn = aws_iam_policy.nf_read_S3.arn
 }
 
+resource "aws_iam_role_policy_attachment" "ecs_kms" {
+  role       = aws_iam_role.nf_ecs_role.name
+  policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
+}
+
+
 ### Spotfleet Role
 resource "aws_iam_role" "nf_spotfleet_role" {
   name = "openscpca-nf-spotfleet-role"
@@ -82,4 +92,9 @@ resource "aws_iam_role_policy_attachment" "nf_spotfleet_tagging" {
 resource "aws_iam_role_policy_attachment" "nf_spotfleet_autoscale" {
   role       = aws_iam_role.nf_spotfleet_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetAutoscaleRole"
+}
+
+resource "aws_iam_role_policy_attachment" "nf_spotfleet_kms" {
+  role       = aws_iam_role.nf_spotfleet_role.name
+  policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
 }

--- a/terraform/nextflow-roles.tf
+++ b/terraform/nextflow-roles.tf
@@ -32,7 +32,7 @@ resource "aws_iam_role_policy_attachment" "nf_batch_full_access" {
 
 resource "aws_iam_role_policy_attachment" "batch_kms" {
   role       = aws_iam_role.nf_batch_role.name
-  policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
+  policy_arn = "arn:aws:iam::${local.account_id}:policy/workload-analysis-kms-readwrite"
 }
 
 ### ECS Role
@@ -74,7 +74,7 @@ resource "aws_iam_role_policy_attachment" "ecs_auto_scale_ebs" {
 
 resource "aws_iam_role_policy_attachment" "ecs_kms" {
   role       = aws_iam_role.nf_ecs_role.name
-  policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
+  policy_arn = "arn:aws:iam::${local.account_id}:policy/workload-analysis-kms-readwrite"
 }
 
 
@@ -108,5 +108,5 @@ resource "aws_iam_role_policy_attachment" "nf_spotfleet_autoscale" {
 
 resource "aws_iam_role_policy_attachment" "nf_spotfleet_kms" {
   role       = aws_iam_role.nf_spotfleet_role.name
-  policy_arn = "arn:aws:iam::992382809252:policy/workload-analysis-kms-readwrite"
+  policy_arn = "arn:aws:iam::${local.account_id}:policy/workload-analysis-kms-readwrite"
 }

--- a/terraform/nextflow-security.tf
+++ b/terraform/nextflow-security.tf
@@ -4,6 +4,13 @@ resource "aws_security_group" "nf_security" {
   name   = "openscpca-nf-security-group"
   vpc_id = aws_vpc.nf_vpc.id
 
+  ingress {
+    description = "Allow all traffic from vpc security group"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+  }
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,3 @@
+locals {
+  account_id = "992382809252"
+}


### PR DESCRIPTION
In continuing quest to get Batch running within the new infrastructure, I am here switching to using the queues we set up within the OpenScPCA account structure.

I also updated to use a KMS key for the batch instances that is managed in this repository, and moved the account number out to a variable to make changing it easier.

Unfortunately, we still seem to be missing something to allow the batch jobs to actually run: right now the instance launches but no jobs start from the queue