### PR TITLE
Fix mismatched cell types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=200"]
@@ -24,15 +24,15 @@ repos:
         language: fail
         files: "(conda-meta|pyvenv.cfg|renv/library)"
   - repo: https://github.com/crate-ci/typos
-    rev: v1.20.3
+    rev: v1.21.0
     hooks:
       - id: typos
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.4.2
     hooks:
       - id: ruff-format
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.1
+    rev: v0.4.2
     hooks:
       - id: style-files
       - id: parsable-R

--- a/main.nf
+++ b/main.nf
@@ -26,10 +26,10 @@ if (param_error) {
 
 // **** Main workflow ****
 workflow {
-  example()
+  // example()
   // project channel of [project_id, project_path]
-  // project_ch = Channel.fromPath(Utils.getProjectPaths(release_dir))
-  //   .map{[it.name, it]} // name is the directory name, which will be SCPCP000000 format
+  project_ch = Channel.fromPath(Utils.getProjectPaths(release_dir))
+    .map{[it.name, it]} // name is the directory name, which will be SCPCP000000 format
 
-  // simulate_sce(project_ch)
+   simulate_sce(project_ch)
 }

--- a/main.nf
+++ b/main.nf
@@ -27,7 +27,7 @@ if (param_error) {
 // **** Main workflow ****
 workflow {
   project_ids = params.project?.tokenize(',') ?: []
-  run_all = project_ids.isEmpty() || project_ids[0].lower() == 'all'
+  run_all = project_ids.isEmpty() || project_ids[0].toLowerCase() == 'all'
 
   // example()
   // project channel of [project_id, project_path]

--- a/main.nf
+++ b/main.nf
@@ -26,10 +26,14 @@ if (param_error) {
 
 // **** Main workflow ****
 workflow {
+  project_ids = params.project?.tokenize(',') ?: []
+  run_all = project_ids.isEmpty() || project_ids[0].lower() == 'all'
+
   // example()
   // project channel of [project_id, project_path]
   project_ch = Channel.fromPath(Utils.getProjectPaths(release_dir))
     .map{[it.name, it]} // name is the directory name, which will be SCPCP000000 format
+    .filter{ run_all || it[0] in project_ids }
 
    simulate_sce(project_ch)
 }

--- a/modules/simulate-sce/resources/usr/bin/simulate-sce.R
+++ b/modules/simulate-sce/resources/usr/bin/simulate-sce.R
@@ -128,6 +128,8 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
     )
 
   # replace sample metadata fields with permuted values
+  # make sure sex is a character type before replacement (usually in case of NA values)
+  metadata(sce_sim)$sample_metadata$sex <- as.character(metadata(sce)$sample_metadata$sex)
   metadata(sce_sim)$sample_metadata <- metadata(sce_sim)$sample_metadata |>
     dplyr::rows_update(replacement_metadata, by = "sample_id")
 

--- a/modules/simulate-sce/resources/usr/bin/simulate-sce.R
+++ b/modules/simulate-sce/resources/usr/bin/simulate-sce.R
@@ -249,7 +249,7 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
 
 set.seed(opts$seed)
 
-metadata <- readr::read_tsv(opts$metadata_file, show_col_types = FALSE)
+metadata <- readr::read_tsv(opts$metadata_file, col_types = "c")
 
 # get file list
 sce_files <- list.files(

--- a/modules/simulate-sce/resources/usr/bin/simulate-sce.R
+++ b/modules/simulate-sce/resources/usr/bin/simulate-sce.R
@@ -111,7 +111,7 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
 
   # define a subset of cells to simulate
   ncells <- min(ncells, ncol(sce))
-  cell_subset <- sample.int(ncol(sce), ncells)
+  cell_subset <- sample(colnames(sce), ncells)
   sce_sim <- sce[, cell_subset]
 
   ### Reduce and remove metadata -----------------------------------------------
@@ -136,10 +136,12 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
 
   # reduce the cell type data matrices, if present
   if (!is.null(metadata(sce_sim)$singler_results)) {
-    metadata(sce_sim)$singler_results <- metadata(sce_sim)$singler_results[cell_subset, ]
+    sim_cells <- cell_subset[cell_subset %in% rownames(metadata(sce_sim)$singler_results)]
+    metadata(sce_sim)$singler_results <- metadata(sce_sim)$singler_results[sim_cells, ]
   }
   if (!is.null(metadata(sce_sim)$cellassign_predictions)) {
-    metadata(sce_sim)$cellassign_predictions <- metadata(sce_sim)$cellassign_predictions[cell_subset, ]
+    sim_cells <- cell_subset[cell_subset %in% rownames(metadata(sce_sim)$cellassign_predictions)]
+    metadata(sce_sim)$cellassign_predictions <- metadata(sce_sim)$cellassign_predictions[sim_cells, ]
   }
 
   # Adjust cluster/cell type labels --------------------------------------------

--- a/modules/simulate-sce/resources/usr/bin/simulate-sce.R
+++ b/modules/simulate-sce/resources/usr/bin/simulate-sce.R
@@ -128,8 +128,6 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
     )
 
   # replace sample metadata fields with permuted values
-  # make sure sex is a character type before replacement (usually in case of NA values)
-  metadata(sce_sim)$sample_metadata$sex <- as.character(metadata(sce)$sample_metadata$sex)
   metadata(sce_sim)$sample_metadata <- metadata(sce_sim)$sample_metadata |>
     dplyr::rows_update(replacement_metadata, by = "sample_id")
 
@@ -251,7 +249,8 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
 
 set.seed(opts$seed)
 
-metadata <- readr::read_tsv(opts$metadata_file, col_types = "c")
+# make sure sex is read as a character to prevent all females -> logical false
+metadata <- readr::read_tsv(opts$metadata_file, readr::cols(sex = "c"))
 
 # get file list
 sce_files <- list.files(

--- a/modules/simulate-sce/resources/usr/bin/simulate-sce.R
+++ b/modules/simulate-sce/resources/usr/bin/simulate-sce.R
@@ -250,7 +250,7 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
 set.seed(opts$seed)
 
 # make sure sex is read as a character to prevent all females -> logical false
-metadata <- readr::read_tsv(opts$metadata_file, readr::cols(sex = "c"))
+metadata <- readr::read_tsv(opts$metadata_file, col_types = readr::cols(sex = "c"))
 
 # get file list
 sce_files <- list.files(

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,6 +15,7 @@ nextflow.enable.moduleBinaries = true
 params {
   release_bucket = "openscpca-data-release"
   release_prefix = "current"
+  project = "all"
 
   // Resource maximum settings
   max_cpus = 24


### PR DESCRIPTION
Closes #19

This PR is mainly to fix the bug that occurs when the cell assignment table in metadata does not perfectly match the final set of cells. This can occur when reusing "old" assignments with a different version of the scpca-nf workflow. 

I also fixed a lingering bug in the metadata reading, and added the start of the ability to run a workflow on only one project, which aided testing.

Once this goes in, I will backport the changes to `openscpca-analysis`