### PR TITLE
Add merge workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 .nextflow*
 
 # ignore work directory
-/work/
+work/
+
+# ignore test results
+test/results/
 
 # ignore hidden `DS_Store`
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Further instructions for this will be added in the future, and we expect this to
 The following base command will run the workflow, assuming all AWS permissions are set up correctly:
 
 ```bash
-nextflow run alexslemonade/openscpca-nf -profile batch
+nextflow run AlexsLemonade/OpenScPCA-nf -profile batch
 ```
 
 The workflow also has a couple of entry points other than the main workflow, for testing and creating simulated data.
@@ -27,7 +27,7 @@ nextflow run AlexsLemonade/OpenScPCA-nf -profile batch -entry test
 To run the workflow that creates simulated SCE objects for the OpenScPCA project, you can use the following command:
 
 ```bash
-nextflow run alexslemonade/openscpca-nf -profile batch -entry simulate
+nextflow run AlexsLemonade/OpenScPCA-nf -profile batch -entry simulate
 ```
 
 ## Repository setup

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ nextflow run alexslemonade/openscpca-nf -profile batch
 
 The workflow also has a couple of entry points other than the main workflow, for testing and creating simulated data.
 
-To run a test version the workflow to check permissions and infrastructure setup:
+To run a test version of the workflow to check permissions and infrastructure setup:
 
 ```bash
-nextflow run alexslemonade/openscpca-nf -profile batch -entry test
+nextflow run AlexsLemonade/OpenScPCA-nf -profile batch -entry test
 ```
 
 To run the workflow that creates simulated SCE objects for the OpenScPCA project, you can use the following command:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@ A workflow for running analysis modules ported from the [OpenScPCA-analysis repo
 
 See https://github.com/AlexsLemonade/OpenScPCA-admin/blob/main/technical-docs/nextflow-workflow-specifications.md for initial implementation plans for this workflow.
 
+## Running the workflow
+
+The workflow is currently set up to run best via AWS batch, but some testing may work locally.
+You will need to have appropriate AWS credentials set up to run the workflow on AWS and access the data files.
+Further instructions for this will be added in the future, and we expect this to be run via a GitHub Action for most use cases.
+
+The following base command will run the workflow, assuming all AWS permissions are set up correctly:
+
+```bash
+nextflow run alexslemonade/openscpca-nf -profile batch
+```
+
+The workflow also has a couple of entry points other than the main workflow, for testing and creating simulated data.
+
+To run a test version the workflow to check permissions and infrastructure setup:
+
+```bash
+nextflow run alexslemonade/openscpca-nf -profile batch -entry test
+```
+
+To run the workflow that creates simulated SCE objects for the OpenScPCA project, you can use the following command:
+
+```bash
+nextflow run alexslemonade/openscpca-nf -profile batch -entry simulate
+```
+
 ## Repository setup
 
 This repository uses [`pre-commit`](https://pre-commit.com) to enforce code style and formatting.

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,5 @@
-[default.extend-words]
+[type.tf]
+extend-glob = ["*.tf"]
+
+[type.tf.extend-words]
 kms = "kms"

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -23,8 +23,8 @@ process {
   withLabel: mem_32 {
     memory = {check_memory(32.GB * task.attempt, params.max_memory)}
   }
-  withLabel: mem_max {
-    memory = {task.attempt > 2 ? params.max_memory : check_memory(64.GB * task.attempt, params.max_memory)}
+  withLabel: mem_max { // max memory for tasks that have failed more than twice for OOM
+    memory = {(task.attempt > 2  && task.exitStatus in 137..140) ? params.max_memory : check_memory(64.GB * task.attempt, params.max_memory)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2, params.max_cpus)}

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -24,7 +24,7 @@ process {
     memory = {check_memory(32.GB * task.attempt, params.max_memory)}
   }
   withLabel: mem_max {
-    memory = {task.attempt > 1 ? params.max_memory : check_memory(96.GB, params.max_memory)}
+    memory = {task.attempt > 2 ? params.max_memory : check_memory(64.GB * task.attempt, params.max_memory)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2, params.max_cpus)}

--- a/config/profile_batch.config
+++ b/config/profile_batch.config
@@ -18,7 +18,12 @@ aws {
 process {
   executor = 'awsbatch'
   scratch = false
+
   queue = 'openscpca-nf-batch-default-queue'
+  // switch to the priority queue for known long running tasks if failing
+  withLabel: 'long_running' {
+    queue = { task.attempt < 2 ? 'openscpca-nf-batch-default-queue' : 'openscpca-nf-batch-priority-queue' }
+  }
 }
 
 params {

--- a/config/profile_batch.config
+++ b/config/profile_batch.config
@@ -6,7 +6,7 @@ wave.enabled = true
 fusion.enabled = true
 
 
-aws{
+aws {
   batch{
     maxTransferAttempts = 3
     maxSpotAttempts = 2
@@ -15,8 +15,13 @@ aws{
 }
 
 
-process{
+process {
   executor = 'awsbatch'
   scratch = false
   queue = 'openscpca-nf-batch-default-queue'
+}
+
+params {
+  max_cpus = 64
+  max_memory = 512.GB
 }

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -36,4 +36,27 @@ class Utils {
     def projects = getProjects(release_path)
     return projects.collect{release_path / it}
   }
+
+  static def getProjectFiles(project_path, format = "sce", process_level = "processed"){
+    project_path = Nextflow.file(project_path, type: 'dir')
+    process_level = process_level.toLowerCase()
+    if (!(process_level in ["raw", "filtered", "processed"])){
+      throw new IllegalArgumentException("Unknown process_level '${process_level}'")
+      }
+    def files = []
+    switch (format.toLowerCase()){
+      case ["anndata", "h5ad"]:
+        files = Nextflow.files(project_path / "**_${process_level}_*.h5ad")
+        break
+      case ["sce", "rds"]:
+        def extension="rds"
+        files = Nextflow.files(project_path / "**_${process_level}.rds")
+        break
+      default:
+        throw new IllegalArgumentException("Unknown format '${format}'")
+        break
+    }
+    files = files.findAll{it.size() > 0}
+    return files
+ }
 }

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -51,6 +51,7 @@ class Utils {
     def files = []
     switch (format.toLowerCase()){
       case ["anndata", "h5ad"]:
+        // find all h5ad files in the project directory (** searches all subdirectories)
         files = Nextflow.files(project_dir / "**_${process_level}_*.h5ad")
         break
       case ["sce", "rds"]:

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -6,7 +6,8 @@ import nextflow.Nextflow
  */
 class Utils {
   static def getReleasePath(bucket, release = "current"){
-    def bucket_path = Nextflow.file(bucket)
+
+    def bucket_path = Nextflow.file(bucket, type: 'dir')
     if (!bucket_path.exists()) {
       throw new IllegalArgumentException("Bucket '${bucket}' does not exist")
     }
@@ -37,8 +38,12 @@ class Utils {
     return projects.collect{release_path / it}
   }
 
-  static def getProjectFiles(project_path, format = "sce", process_level = "processed"){
-    project_path = Nextflow.file(project_path, type: 'dir')
+  static def getProjectFiles(Map args, project_dir){
+    def format = args.format ?: "sce"
+    def process_level = args.process_level ?: "processed"
+
+    project_dir = Nextflow.file(project_dir, type: 'dir')
+    println(project_dir)
     process_level = process_level.toLowerCase()
     if (!(process_level in ["raw", "filtered", "processed"])){
       throw new IllegalArgumentException("Unknown process_level '${process_level}'")
@@ -46,11 +51,11 @@ class Utils {
     def files = []
     switch (format.toLowerCase()){
       case ["anndata", "h5ad"]:
-        files = Nextflow.files(project_path / "**_${process_level}_*.h5ad")
+        files = Nextflow.files(project_dir / "**_${process_level}_*.h5ad")
         break
       case ["sce", "rds"]:
         def extension="rds"
-        files = Nextflow.files(project_path / "**_${process_level}.rds")
+        files = Nextflow.files(project_dir / "**_${process_level}.rds")
         break
       default:
         throw new IllegalArgumentException("Unknown format '${format}'")

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -6,7 +6,7 @@ import nextflow.Nextflow
  */
 class Utils {
   static def getReleasePath(bucket, release = "current"){
-    def bucket_path = Nextflow.file("s3://${bucket}")
+    def bucket_path = Nextflow.file("${bucket}")
     if (!bucket_path.exists()) {
       throw new IllegalArgumentException("Bucket ${bucket} does not exist")
     }

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -6,20 +6,21 @@ import nextflow.Nextflow
  */
 class Utils {
   static def getReleasePath(bucket, release = "current"){
-    def bucket_path = Nextflow.file("${bucket}")
+    def bucket_path = Nextflow.file(bucket)
     if (!bucket_path.exists()) {
-      throw new IllegalArgumentException("Bucket ${bucket} does not exist")
+      throw new IllegalArgumentException("Bucket '${bucket}' does not exist")
     }
     if (!release) {
       throw new IllegalArgumentException("release can not be blank")
     }
-    else if (release == "current") {
+    if (release == "current") {
       def today = new Date().format('yyyy-MM-dd')
       release = bucket_path.list().findAll{it <= today}.max()
     }
     def release_path = bucket_path / release
+    println("Using release '${release}' from '${bucket}'")
     if (!release_path.exists()) {
-      throw new IllegalArgumentException("Release ${release} does not exist in ${bucket}")
+      throw new IllegalArgumentException("Release '${release}' does not exist in '${bucket}'")
     }
     return release_path
   }

--- a/main.nf
+++ b/main.nf
@@ -25,12 +25,24 @@ if (param_error) {
   System.exit(1)
 }
 
+workflow example {
+  example()
+}
+
+workflow simulate {
+  project_ids = params.project?.tokenize(',') ?: []
+  run_all = project_ids.isEmpty() || project_ids[0].toLowerCase() == 'all'
+
+  project_ch = Channel.fromPath(Utils.getProjectPaths(release_dir))
+    .map{[it.name, it]} // name is the directory name, which will be SCPCP000000 format
+    .filter{ run_all || it[0] in project_ids }
+  simulate_sce(project_ch)
+}
+
 // **** Main workflow ****
 workflow {
   project_ids = params.project?.tokenize(';, ') ?: []
   run_all = project_ids.isEmpty() || project_ids[0].toLowerCase() == 'all'
-
-  // example()
 
   // project channel of [project_id, project_path]
   project_ch = Channel.fromPath(Utils.getProjectPaths(release_dir))
@@ -38,6 +50,4 @@ workflow {
     .filter{ run_all || it[0] in project_ids }
 
   merge_sce(project_ch)
-
-  // simulate_sce(project_ch)
 }

--- a/main.nf
+++ b/main.nf
@@ -25,7 +25,7 @@ if (param_error) {
   System.exit(1)
 }
 
-workflow example {
+workflow test {
   example()
 }
 

--- a/main.nf
+++ b/main.nf
@@ -3,6 +3,7 @@
 // **** Included processes from modules ****
 include { example } from './modules/example'
 include { simulate_sce } from './modules/simulate-sce'
+include { merge_sce } from './modules/merge-sce'
 
 // **** Parameter checks ****
 param_error = false
@@ -35,5 +36,7 @@ workflow {
     .map{[it.name, it]} // name is the directory name, which will be SCPCP000000 format
     .filter{ run_all || it[0] in project_ids }
 
-   simulate_sce(project_ch)
+  merge_sce(project_ch)
+
+  // simulate_sce(project_ch)
 }

--- a/main.nf
+++ b/main.nf
@@ -27,7 +27,7 @@ if (param_error) {
 
 // **** Main workflow ****
 workflow {
-  project_ids = params.project?.tokenize(',') ?: []
+  project_ids = params.project?.tokenize(';, ') ?: []
   run_all = project_ids.isEmpty() || project_ids[0].toLowerCase() == 'all'
 
   // example()

--- a/modules/example/main.nf
+++ b/modules/example/main.nf
@@ -11,8 +11,8 @@ process say_hello{
 }
 
 workflow example {
-  names = Channel.from(["Alex", "World"])
-  say_hello(names).subscribe{
+  names_ch = Channel.from(["Alex", "World"])
+  say_hello(names_ch).subscribe{
     log.info(it.getText())
   }
 }

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -98,7 +98,7 @@ process export_anndata {
 
       # move normalized counts to X in AnnData
       move_counts_anndata.py --anndata_file ${rna_h5ad_file}
-      if [ -f "${feature_h5ad_file}" ]; then
+      if [ -f ${feature_h5ad_file} ]; then
         move_counts_anndata.py --anndata_file ${feature_h5ad_file}
       fi
       """

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -5,6 +5,7 @@
 
 // module parameters
 params.reuse_merge = false
+params.num_hvg = 2000 // number of HVGs to select
 
 // merge workflow variables
 def publish_merge_base = "${params.results_bucket}/${params.release_prefix}/merge_sce"
@@ -31,6 +32,7 @@ process merge_group {
       --input_library_ids '${input_library_ids}' \
       --input_sce_files '${input_sces}' \
       --output_sce_file '${merged_sce_file}' \
+      --n_hvg ${params.num_hvg} \
       --threads ${task.cpus}
     """
 

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -1,5 +1,4 @@
 #!/usr/bin/env nextflow
-nextflow.enable.dsl=2
 
 // Workflow to merge SCE objects into a single object.
 // This workflow does NOT perform integration, i.e. batch correction.
@@ -7,11 +6,9 @@ nextflow.enable.dsl=2
 // module parameters
 params.reuse_merge = false
 
-
-// workflow variables
-def module_dir = "${projectDir}/modules/merge-sce"
+// merge workflow variables
 def publish_merge_base = "${params.results_bucket}/${params.release_version}/merge_sce"
-def merge_report_template = "${module_dir}/resources/merge-report.rmd"
+def merge_report_template = "${projectDir}/modules/merge-sce/resources/merge-report.rmd"
 
 // merge individual SCE objects into one SCE object
 process merge_sce {

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -58,13 +58,15 @@ process generate_merge_report {
   script:
     def merge_report = "${merge_group_id}_merged-summary-report.html"
     """
-    Rscript -e "rmarkdown::render( \
-      '${report_template}', \
-      output_file = '${merge_report}', \
-      params = list(merge_group = '${merge_group_id}', \
-                    merged_sce_file = '${merged_sce_file}', \
-                    batch_column = 'library_id') \
-      )"
+    #!/usr/bin/env Rscript
+
+    rmarkdown::render(
+      '${report_template}',
+      output_file = '${merge_report}',
+      params = list(merge_group = '${merge_group_id}',
+                    merged_sce_file = '${merged_sce_file}',
+                    batch_column = 'library_id')
+    )
     """
   stub:
     def merge_report = "${merge_group_id}_merged-summary-report.html"

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -8,7 +8,8 @@ params.reuse_merge = false
 params.num_hvg = 2000 // number of HVGs to select
 
 // merge workflow variables
-def publish_merge_base = "${params.results_bucket}/${params.release_prefix}/merge_sce"
+def module_name = "merge-sce"
+def publish_merge_base = "${params.results_bucket}/${params.release_prefix}/${module_name}"
 def merge_report_template = "${projectDir}/modules/merge-sce/resources/merge-report.rmd"
 
 

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -98,14 +98,16 @@ process export_anndata {
 
       # move normalized counts to X in AnnData
       move_counts_anndata.py --anndata_file ${rna_h5ad_file}
-      ${has_adt ? "move_counts_anndata.py --anndata_file ${feature_h5ad_file}" : ''}
+      if [ -f "${feature_h5ad_file}" ]; then
+        move_counts_anndata.py --anndata_file ${feature_h5ad_file}
+      fi
       """
     stub:
       rna_h5ad_file = "${merge_group_id}_merged_rna.h5ad"
       feature_h5ad_file = "${merge_group_id}_merged_adt.h5ad"
       """
       touch ${rna_h5ad_file}
-      ${has_adt ? "touch ${feature_h5ad_file}" : ''}
+      touch ${feature_h5ad_file}
       """
 }
 
@@ -142,10 +144,9 @@ workflow merge_sce {
       }
 
     pre_merged_ch = libraries_branch.has_merge
-      .map{[ // [project id, merged_file, has_adt] to match the output of merge_sce
+      .map{[ // [project id, merged_file] to match the output of merge_group
         it[0],
-        file("${publish_merge_base}/${it[0]}/${it[0]}_merged.rds"),
-        it[3]
+        file("${publish_merge_base}/${it[0]}/${it[0]}_merged.rds")
       ]}
 
     // merge SCE objects

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -124,11 +124,11 @@ workflow merge_sce {
     // get all SCE files by project
     // this will be a channel of [project_id, [library_ids], [processed_sce_files]]
     libraries_ch = project_branch.single_sample
-      .map{project_id, project_dir -> {
+      .map{ project_id, project_dir ->
         def processed_files = Utils.getProjectFiles(project_dir, format: "sce", process_level: "processed")
         def library_ids = processed_files.collect{it.name.replace('_processed.rds', '')}
         return [project_id, library_ids, processed_files]
-      }}
+      }
 
     project_branch.multiplexed
       .subscribe{

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -125,6 +125,7 @@ workflow merge_sce {
     libraries_ch = project_branch.single_sample
       .map{project_id, project_dir -> {
         def processed_files = files(project_dir / "**_processed.rds")
+        processed_files = processed_files.findAll{it.size() > 0} // remove empty files
         def library_ids = processed_files.collect{it.name.replace('_processed.rds', '')}
         def has_adt = files(project_dir / "**_processed_adt.h5ad").size > 0 // true if there are any adt files
         return [project_id, library_ids, processed_files, has_adt]

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -1,0 +1,213 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+// Workflow to merge SCE objects into a single object.
+// This workflow does NOT perform integration, i.e. batch correction.
+
+// module parameters
+params.reuse_merge = false
+
+
+// workflow variables
+def module_dir = "${projectDir}/modules/merge-sce"
+def publish_merge_base = "${params.results_bucket}/${params.release_version}/merge_sce"
+def merge_report_template = "${module_dir}/resources/merge-report.rmd"
+
+// merge individual SCE objects into one SCE object
+process merge_sce {
+  container ghcr.io/alexslemonade/scpcatools-slim:edge
+  tag "${merge_group_id}"
+  label 'mem_max'
+  label 'long_running'
+  publishDir "${publish_merge_base}/${merge_group_id}"
+  input:
+    tuple val(merge_group_id), val(library_ids), path(processed_files)
+  output:
+    tuple path(merged_sce_file), val(merge_group_id), val(has_adt)
+  script:
+    def input_library_ids = library_ids.join(',')
+    def input_sces = processed_files.join(',')
+    def merged_sce_file = "${merge_group_id}_merged.rds"
+    """
+    merge_sces.R \
+      --input_library_ids "${input_library_ids}" \
+      --input_sce_files "${input_sces}" \
+      --output_sce_file "${merged_sce_file}" \
+      --n_hvg ${params.num_hvg} \
+      --threads ${task.cpus}
+    """
+  stub:
+    def merged_sce_file = "${merge_group_id}_merged.rds"
+    """
+    touch ${merged_sce_file}
+    """
+
+}
+
+// create merge report
+process generate_merge_report {
+  container ghcr.io/alexslemonade/scpcatools-reports:edge
+  tag "${merge_group_id}"
+  publishDir "${params.results_dir}/${merge_group_id}/merged"
+  label 'mem_max'
+  input:
+    tuple path(merged_sce_file), val(merge_group_id), val(has_adt)
+    path(report_template)
+  output:
+    path(merge_report)
+  script:
+    def merge_report = "${merge_group_id}_merged-summary-report.html"
+    """
+    Rscript -e "rmarkdown::render( \
+      '${report_template}', \
+      output_file = '${merge_report}', \
+      params = list(merge_group = '${merge_group_id}', \
+                    merged_sce_file = '${merged_sce_file}', \
+                    batch_column = 'library_id') \
+      )"
+    """
+  stub:
+    def merge_report = "${merge_group_id}_merged-summary-report.html"
+    """
+    touch ${merge_report}
+    """
+}
+
+process export_anndata {
+    container ghcr.io/alexslemonade/scpcatools-anndata:edge
+    label 'mem_max'
+    label 'long_running'
+    tag "${merge_group_id}"
+    publishDir "${params.results_dir}/${merge_group_id}/merged", mode: 'copy'
+    input:
+      tuple path(merged_sce_file), val(merge_group_id), val(has_adt)
+    output:
+      tuple val(merge_group_id), path("${merge_group_id}_merged_*.h5ad")
+    script:
+      def rna_h5ad_file = "${merge_group_id}_merged_rna.h5ad"
+      def feature_h5ad_file = "${merge_group_id}_merged_adt.h5ad"
+      """
+      sce_to_anndata.R \
+        --input_sce_file ${merged_sce_file} \
+        --output_rna_h5 ${rna_h5ad_file} \
+        --output_feature_h5 ${feature_h5ad_file} \
+        --is_merged \
+        ${has_adt ? "--feature_name adt" : ''}
+
+      # move normalized counts to X in AnnData
+      move_counts_anndata.py --anndata_file ${rna_h5ad_file}
+      ${has_adt ? "move_counts_anndata.py --anndata_file ${feature_h5ad_file}" : ''}
+      """
+    stub:
+      def rna_h5ad_file = "${merge_group_id}_merged_rna.h5ad"
+      def feature_h5ad_file = "${merge_group_id}_merged_adt.h5ad"
+      """
+      touch ${rna_h5ad_file}
+      ${has_adt ? "touch ${feature_h5ad_file}" : ''}
+      """
+}
+
+workflow merge_sce{
+  take:
+    project_ch  // Channel of project names and project directories
+  main:
+    // grab run ids to include
+    run_ids = params.merge_run_ids?.tokenize(',') ?: []
+    // if no run ids, run all
+    run_all = run_ids[0] == "All"
+
+    // read in run metafile and filter to projects of interest
+    libraries_ch = Channel.fromPath(params.run_metafile)
+      .splitCsv(header: true, sep: '\t')
+      // filter to only include specified project ids
+      .filter{it.scpca_project_id in project_ids}
+      // filter to run all ids or just specified ones
+      .filter{
+        run_all
+        || (it.scpca_run_id in run_ids)
+        || (it.scpca_library_id in run_ids)
+        || (it.scpca_sample_id in run_ids)
+      }
+      .map{[
+        seq_unit: it.seq_unit,
+        technology: it.technology,
+        project_id: it.scpca_project_id,
+        library_id: it.scpca_library_id,
+        sample_id: it.scpca_sample_id.split(";").sort().join(",")
+      ]}
+
+    // get all projects that contain at least one library with CITEseq
+    adt_projects = libraries_ch
+      .filter{it.technology.startsWith('CITEseq')}
+      .collect{it.project_id}
+      .map{it.unique()}
+
+    multiplex_projects = libraries_ch
+      .filter{it.technology.startsWith('cellhash')}
+      .collect{it.project_id}
+      .map{it.unique()}
+
+    filtered_libraries_ch = libraries_ch
+      // only include single-cell/single-nuclei which ensures we don't try to merge libraries from spatial or bulk data
+      .filter{it.seq_unit in ['cell', 'nucleus']}
+      // remove any multiplexed projects
+      // future todo: only filter library ids that are multiplexed, but keep all other non-multiplexed libraries
+      .branch{
+        multiplexed: it.project_id in multiplex_projects.getVal()
+        single_sample: true
+      }
+
+    filtered_libraries_ch.multiplexed
+      .unique{ it.project_id }
+      .subscribe{
+        log.warn("Not merging ${it.project_id} because it contains multiplexed libraries.")
+      }
+
+    // print out warning message for any libraries not included in merging
+    filtered_libraries_ch.single_sample
+      .map{[
+        it.library_id,
+        file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed.rds")
+      ]}
+    .filter{!(it[1].exists() && it[1].size() > 0)}
+    .subscribe{
+      log.warn("Processed files do not exist for ${it[0]}. This library will not be included in the merged object.")
+    }
+
+    grouped_libraries_ch = filtered_libraries_ch.single_sample
+      // create tuple of [project id, library_id, processed_sce_file]
+      .map{[
+        it.project_id,
+        it.library_id,
+        file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed.rds")
+      ]}
+      // only include libraries that have been processed through scpca-nf and aren't empty
+      .filter{it[2].exists() && it[2].size() > 0}
+      // only one row per library ID, this removes all the duplicates that may be present due to CITE/hashing
+      .unique()
+      // group tuple by project id: [project_id, [library_id1, library_id2, ...], [sce_file1, sce_file2, ...]]
+      .groupTuple(by: 0)
+      .branch{
+        has_merge: file("${publish_merge_base}/${it[0]}/${it[0]}_merged.rds").exists() && params.reuse_merge
+        make_merge: true
+      }
+
+    pre_merged_ch = grouped_libraries_ch.has_merge
+      .map{[ // merge file, project id, has adt
+        file("${publish_merge_base}/${it[0]}/${it[0]}_merged.rds"),
+        it[0],
+        it[1]
+      ]}
+
+    // merge SCE objects
+    merge_sce(grouped_libraries_ch.make_merge)
+
+    merged_ch = merge_sce.out.mix(pre_merged_ch)
+
+
+    // generate merge report
+    generate_merge_report(merged_ch, file(merge_report_template))
+
+    // export merged objects to AnnData
+    export_anndata(merged_ch)
+}

--- a/modules/merge-sce/readme.md
+++ b/modules/merge-sce/readme.md
@@ -1,0 +1,1 @@
+# Workflow for merging SCE files for a given project

--- a/modules/merge-sce/readme.md
+++ b/modules/merge-sce/readme.md
@@ -1,1 +1,15 @@
 # Workflow for merging SCE files for a given project
+
+This workflow creates merged SCE files and associated AnnData files from a project's individual SCE files.
+
+The workflow and scripts are largely ported from the [`scpca-nf` workflow](https://github.com/AlexsLemonade/scpca-nf).
+The [a9dc826 commit](https://github.com/AlexsLemonade/scpca-nf/tree/a9dc826b8576c48ca38c6ca137f9eeced29c3acc) was used as the base for the port.
+
+There have been some small changes, in particular:
+
+- Containers have been updated to use a more recent version of `scpcaTools`, with underlying updates to Bioconductor and Python packages.
+- The workflow is run on a project level, and all SCE files within a project are merged.
+  - the assumption in this workflow is that all libraries within a project are to be merged, so there (currently) are no options to specify which specific samples to merge.
+- Presence of ADTs is determined within the workflow by the presence of `_adt.h5ad` files among the sample files.
+  - The `--include_adt` flag was also removed from the `merge_sces.R` script, replaced by looking directly at the SCE objects
+  - This means that if there are ADTs in the project, they will be present in the merged SCE file, but there will be merged AnnData files depending only on whether there were individual AnnData ADT files.

--- a/modules/merge-sce/readme.md
+++ b/modules/merge-sce/readme.md
@@ -10,6 +10,5 @@ There have been some small changes, in particular:
 - Containers have been updated to use a more recent version of `scpcaTools`, with underlying updates to Bioconductor and Python packages.
 - The workflow is run on a project level, and all SCE files within a project are merged.
   - the assumption in this workflow is that all libraries within a project are to be merged, so there (currently) are no options to specify which specific samples to merge.
-- Presence of ADTs is determined within the workflow by the presence of `_adt.h5ad` files among the sample files.
   - The `--include_adt` flag was also removed from the `merge_sces.R` script, replaced by looking directly at the SCE objects
-  - This means that if there are ADTs in the project, they will be present in the merged SCE file, but there will be merged AnnData files depending only on whether there were individual AnnData ADT files.
+  - The `sce_to_anndata.R` script now only warns if the requested feature altExp is not found in the SCE file, rather than erroring out.

--- a/modules/merge-sce/resources/merge-report.rmd
+++ b/modules/merge-sce/resources/merge-report.rmd
@@ -1,0 +1,383 @@
+---
+params:
+  merge_group: "example_group"
+  merged_sce_file: NULL
+  batch_column: "library_id"
+title: "`r glue::glue('ScPCA merged report for {params$merge_group}')`"
+author: "Childhood Cancer Data Lab"
+date: "`r params$date`"
+output:
+  html_document:
+    toc: true
+    toc_depth: 2
+    toc_float:
+      collapsed: false
+    number_sections: false
+    code_download: true
+---
+
+```{r setup, warning = FALSE, message = FALSE, echo = FALSE}
+# knitr options
+knitr::opts_chunk$set(
+  echo = FALSE
+)
+
+library(SingleCellExperiment)
+library(ggplot2)
+
+# Set default ggplot theme, customized for UMAPs
+theme_set(
+  theme_bw() +
+    theme(
+      plot.margin = margin(rep(20, 4)),
+      axis.text = element_blank(),
+      axis.ticks = element_blank(),
+      panel.grid = element_blank(),
+      aspect.ratio = 1
+    )
+)
+```
+
+```{r}
+# define a simple function for creating tables
+make_kable <- function(df) {
+  knitr::kable(df, align = "r") |>
+    kableExtra::kable_styling(
+      bootstrap_options = "striped",
+      full_width = FALSE,
+      position = "left"
+    ) |>
+    kableExtra::column_spec(2, monospace = TRUE)
+}
+```
+
+
+```{r}
+# check that input file is provided and ends in rds
+if (is.null(params$merged_sce_file)) {
+  stop("Must provide a merged SCE object file.")
+}
+if (!stringr::str_ends(params$merged_sce_file, ".rds")) {
+  stop("Merged object file must end in .rds.")
+}
+
+# read in merged sce from file
+merged_sce <- readr::read_rds(params$merged_sce_file)
+
+# define batch column
+batch_column <- params$batch_column
+
+# set adt/multiplex values
+# this tells us if at least one library contains either of these modalities
+additional_sce_modalities <- merged_sce$additional_modalities |>
+  stringr::str_split(pattern = ";") |>
+  purrr::reduce(union) |>
+  sort()
+
+has_adt <- "adt" %in% additional_sce_modalities
+multiplexed <- "cellhash" %in% additional_sce_modalities
+```
+
+```{r, integration-warning, eval=FALSE}
+glue::glue("
+    <div class=\"alert alert-warning\">
+
+    <b>CAUTION: The libraries included in the merged object are NOT integrated or batch-corrected.</b>
+
+    </div>
+  ")
+```
+
+```{r, ref.label=c('integration-warning'), eval=TRUE, results='asis'}
+```
+
+
+This report includes a brief summary of all libraries included in the merged object for `r params$merge_group`.
+This merged object is intended to facilitate downstream analyses across multiple samples.
+
+The libraries included in the merged object are _NOT integrated or batch-corrected_.
+To conduct any downstream analyses that require batch correction (e.g., UMAP or clustering), batch correction must be performed separately.
+
+# Library information
+
+```{r}
+# extract coldata as data frame to use to create tables and UMAPs
+coldata_df <- scuttle::makePerCellDF(merged_sce, use.dimred = "UMAP") |>
+  dplyr::rename(
+    UMAP1 = UMAP.1,
+    UMAP2 = UMAP.2
+  )
+
+num_libraries <- merged_sce$library_id |>
+  unique() |>
+  length()
+```
+
+The merged object summarized in this report is comprised of `r num_libraries` individual libraries, which are described in the following table.
+
+- `Technology version` indicates which 10X Genomics kit was used for library preparation.
+- `Experimental factor ontology` indicates the associated [Experimental factor ontology](https://www.ebi.ac.uk/efo/) (EFO) for the specified 10X version.
+- `Suspension type` indicates if the library was prepared from a single-cell (`cell`) or single-nuclei (`nucleus`) suspension.
+
+
+```{r}
+# table summarizing number of libraries with tech version and seq unit
+tech_table <- coldata_df |>
+  dplyr::select(library_id, tech_version, assay_ontology_term_id, suspension_type) |>
+  dplyr::distinct() |>
+  dplyr::count(tech_version, assay_ontology_term_id, suspension_type) |>
+  dplyr::arrange(desc(n)) |>
+  dplyr::rename(
+    "Technology version" = "tech_version",
+    "Experimental factor ontology" = "assay_ontology_term_id",
+    "Suspension type" = "suspension_type",
+    "Number of libraries" = "n"
+  )
+
+make_kable(tech_table)
+```
+
+
+```{r, eval=has_adt}
+knitr::asis_output(glue::glue(
+  "
+  This merged object contains one or more libraries with accompanying antibody-derived tag (ADT) expression data.
+  The following table summarizes the number of libraries with and without ADT data.
+  "
+))
+
+# count number of libraries with and without ADT
+adt_table <- coldata_df |>
+  dplyr::select(library_id, additional_modalities) |>
+  dplyr::distinct() |>
+  dplyr::mutate(
+    contains_adt = ifelse(
+      # check the corresponding column, same row
+      "adt" == additional_modalities, "Contains ADT", "No ADT"
+    )
+  ) |>
+  dplyr::count(contains_adt) |>
+  dplyr::rename(
+    "Library type" = "contains_adt",
+    "Number of libraries" = "n"
+  )
+
+make_kable(adt_table)
+```
+
+
+```{r, eval=multiplexed }
+knitr::asis_output(glue::glue(
+  "
+  This merged object contains one or more libraries that have been multiplexed.
+  The following table summarizes the number of libraries that have and have not been multiplexed.
+  "
+))
+
+# count number of libraries with and without multiplexing
+multiplex_table <- coldata_df |>
+  dplyr::select(library_id, additional_modalities) |>
+  dplyr::distinct() |>
+  dplyr::mutate(
+    is_multiplexed = ifelse(
+      # check the corresponding column, same row
+      "cellhash" == additional_modalities, "Multiplexed", "Not multiplexed"
+    )
+  ) |>
+  dplyr::count(is_multiplexed) |>
+  dplyr::rename(
+    "Library type" = "is_multiplexed",
+    "Number of libraries" = "n"
+  )
+
+make_kable(multiplex_table)
+```
+
+
+# Sample information
+
+```{r, eval = multiplexed, results='asis'}
+# get the total number of libraries that have been multiplexed
+n_multiplexed <- multiplex_table |>
+  dplyr::filter(`Library type` == "Multiplexed") |>
+  dplyr::pull(`Number of libraries`)
+
+glue::glue("
+  <div class=\"alert alert-info\">
+
+  This merged object contains {n_multiplexed} libraries that have been multiplexed.
+  Demultiplexing has not been performed, so sample information will not be displayed.
+
+  </div>
+")
+```
+
+
+```{r, eval=!multiplexed}
+# get total number of samples and libraries
+num_samples <- merged_sce$sample_id |>
+  unique() |>
+  length()
+```
+
+
+```{r, eval=!multiplexed, results='asis'}
+glue::glue(
+  "
+  The merged object summarized in this report contains {num_samples} samples.
+  "
+)
+```
+
+
+```{r, eval=!multiplexed}
+knitr::asis_output("
+## Diagnoses
+
+The following table shows the total number of samples associated with each diagnosis.
+If a subdiagnosis is available, the total number of samples will be shown for each unique combination of diagnosis and subdiagnosis.
+
+")
+```
+
+
+```{r, eval=!multiplexed}
+# table of diagnosis
+diagnosis_table <- coldata_df |>
+  dplyr::select(sample_id, diagnosis, subdiagnosis) |>
+  dplyr::distinct()
+
+# if subdiagnosis is present, summarize both
+if (!all(is.na(diagnosis_table$subdiagnosis))) {
+  diagnosis_table <- diagnosis_table |>
+    dplyr::count(diagnosis, subdiagnosis) |>
+    dplyr::arrange(desc(n)) |>
+    dplyr::rename(
+      "Diagnosis" = "diagnosis",
+      "Subdiagnosis" = "subdiagnosis",
+      "Number of samples" = "n"
+    )
+} else {
+  # otherwise only count diagnosis
+  diagnosis_table <- diagnosis_table |>
+    dplyr::count(diagnosis) |>
+    dplyr::arrange(desc(n)) |>
+    dplyr::rename(
+      "Diagnosis" = "diagnosis",
+      "Number of samples" = "n"
+    )
+}
+
+make_kable(diagnosis_table)
+```
+
+
+```{r, eval=!multiplexed}
+knitr::asis_output(
+  "
+## Disease stage
+
+The following table shows both the diagnosis and at what point during disease progression (`Disease stage`) the sample was taken.
+
+"
+)
+```
+
+
+```{r, eval=!multiplexed}
+# count number of samples per diagnosis/ disease timing combination
+disease_timing_table <- coldata_df |>
+  dplyr::select(sample_id, diagnosis, disease_timing) |>
+  dplyr::distinct() |>
+  dplyr::count(diagnosis, disease_timing) |>
+  dplyr::arrange(desc(n)) |>
+  dplyr::rename(
+    "Diagnosis" = "diagnosis",
+    "Disease stage" = "disease_timing",
+    "Number of samples" = "n"
+  )
+
+make_kable(disease_timing_table)
+```
+
+
+
+# UMAPs
+
+```{r, ref.label=c('integration-warning'), eval=TRUE, results='asis'}
+```
+
+In this section, we present UMAPs showing all cells from all libraries included in the merged object.
+For each library, a separate panel is shown, and cells from that library are colored, while all other cells are gray.
+
+**These merged object UMAP coordinates differ from UMAPs in individual library files.**
+After individual objects were merged, PCA and UMAP coordinate were recalculated so that each library would contribute equally to the overall scaling.
+As a consequence, the PCA and UMAP coordinates found in the merged object will differ from the coordinates found in individual libraries.
+
+```{r}
+# Determine appropriate dimensions for UMAP based on number of libraries
+n_libraries <- sum(tech_table$`Number of libraries`)
+
+# Determine faceting layout based on n_libraries
+# TODO: This needs to be revisited when we run the merged objects through
+facet_ncol <- dplyr::case_when(
+  n_libraries <= 20 ~ 4,
+  n_libraries <= 50 ~ 6,
+  n_libraries <= 80 ~ 8,
+  .default = 10
+)
+
+# TODO: For now, 3 inches per UMAP row
+umap_height <- ceiling(n_libraries / facet_ncol) * 3
+```
+
+
+
+```{r, eval = multiplexed, results = 'asis'}
+glue::glue("
+ <div class=\"alert alert-info\">
+ This merged object contains multiplexed data.
+ Each UMAP facet displays a given library, which may be comprised of multiple samples.
+  </div>
+")
+```
+
+
+```{r, fig.width = 8, fig.height = umap_height}
+ggplot(
+  coldata_df,
+  aes(x = UMAP1, y = UMAP2, color = {{ batch_column }})
+) +
+  # set points for all "other" points
+  geom_point(
+    data = dplyr::select(
+      coldata_df, -{{ batch_column }}
+    ),
+    color = "gray80",
+    alpha = 0.5,
+    size = 0.1
+  ) +
+  # set points for desired cell type
+  geom_point(
+    alpha = 0.5,
+    size = 0.1,
+    color = "firebrick3"
+  ) +
+  facet_wrap(
+    {{ batch_column }}, # do NOT use vars()
+    ncol = facet_ncol
+  )
+```
+
+
+# Session Info
+<details>
+<summary>R session information</summary>
+```{r session_info}
+if (requireNamespace("sessioninfo", quietly = TRUE)) {
+  sessioninfo::session_info()
+} else {
+  sessionInfo()
+}
+```
+</details>

--- a/modules/merge-sce/resources/usr/bin/merge_sces.R
+++ b/modules/merge-sce/resources/usr/bin/merge_sces.R
@@ -150,7 +150,7 @@ if ("singler" %in% all_celltypes) {
   # Check if the label used for annotation was ontology in at least 1 SCE
   use_ontology <- sce_list |>
     purrr::map_lgl(\(sce) {
-      any(metadata(sce)$singler_reference_label == "label.ont")
+      "label.ont" %in% metadata(sce)$singler_reference_label
     }) |>
     any()
 

--- a/modules/merge-sce/resources/usr/bin/merge_sces.R
+++ b/modules/merge-sce/resources/usr/bin/merge_sces.R
@@ -170,7 +170,7 @@ if ("cellassign" %in% all_celltypes) {
   # Add `"Cell type annotation not performed"` string to libraries without CellAssign,
   #  and make the max prediction `NA_real_` for extra safety
   sce_list <- sce_list |>
-    purrr::map(\(sce){
+    purrr::map(\(sce) {
       if (!"cellassign" %in% metadata(sce)$celltype_methods) {
         colData(sce)$cellassign_celltype_annotation <- "Cell type annotation not performed"
         colData(sce)$cellassign_max_prediction <- NA_real_

--- a/modules/merge-sce/resources/usr/bin/merge_sces.R
+++ b/modules/merge-sce/resources/usr/bin/merge_sces.R
@@ -1,0 +1,350 @@
+#!/usr/bin/env Rscript
+
+# import libraries
+library(optparse)
+library(SingleCellExperiment)
+
+# Set up optparse options
+option_list <- list(
+  make_option(
+    opt_str = c("--input_library_ids"),
+    type = "character",
+    help = "Comma separated list of library IDs corresponding to the libraries being merged."
+  ),
+  make_option(
+    opt_str = c("--input_sce_files"),
+    type = "character",
+    help = "Comma separated list of input sce file paths corresponding to the sces being merged."
+  ),
+  make_option(
+    opt_str = c("-o", "--output_sce_file"),
+    type = "character",
+    help = "Path to output RDS file, must end in .rds"
+  ),
+  make_option(
+    opt_str = c("--n_hvg"),
+    type = "integer",
+    default = 2000,
+    help = "number of high variance genes to use for dimension reduction;
+            the default is n_hvg = 2000"
+  ),
+  make_option(
+    opt_str = c("--multiplexed"),
+    action = "store_true",
+    default = FALSE,
+    help = "Indicates if the provided SCE's contain multiplexed data.
+      If so, the sample metadata will not be added to the colData."
+  ),
+  make_option(
+    opt_str = c("-t", "--threads"),
+    type = "integer",
+    default = 1,
+    help = "Number of multiprocessing threads to use"
+  )
+)
+
+# Setup ------------------------------------------------------------------------
+
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# check that file extension for output file is correct
+if (!(stringr::str_ends(opt$output_sce_file, ".rds"))) {
+  stop("output file name must end in .rds")
+}
+
+# check that input files are provided and more than one are present for merging and integration
+if (is.null(opt$input_sce_files)) {
+  stop("List of input files containing individual SCE objects to merge is missing.")
+} else {
+  # list of paths to sce files
+  input_sce_files <- unlist(stringr::str_split(opt$input_sce_files, ","))
+}
+
+if (length(input_sce_files) == 1) {
+  stop("Only 1 input file provided, no merging will be performed for this group")
+}
+
+# use library ids to name list of input files
+if (is.null(opt$input_library_ids)) {
+  # extract library ids from filename
+  names(input_sce_files) <- stringr::word(basename(input_sce_files), 1, sep = "_")
+} else {
+  # pull library ids from list
+  names(input_sce_files) <- unlist(stringr::str_split(opt$input_library_ids, ","))
+}
+
+# sort inputs by library id
+input_sce_files <- input_sce_files[order(names(input_sce_files))]
+
+# check that input files exist
+missing_sce_files <- input_sce_files[which(!file.exists(input_sce_files))]
+if (length(missing_sce_files) > 0) {
+  stop(
+    glue::glue(
+      "\nCannot find input file: {missing_sce_files}."
+    )
+  )
+}
+
+# set up multiprocessing params
+if (opt$threads > 1) {
+  bp_param <- BiocParallel::MulticoreParam(opt$threads)
+} else {
+  bp_param <- BiocParallel::SerialParam()
+}
+
+# Functions
+
+read_trim_sce <- function(sce_file) {
+  # Read in SCE and update some information to reduce size/memory usage
+
+  sce <- readr::read_rds(sce_file)
+  if (!is(sce, "SingleCellExperiment")) {
+    stop("Input file must contain a `SingleCellExperiment` object.")
+  }
+  # Update some SCE information  -------------------------------------------------
+  # - Add a new colData column with any additional modalities
+  # - Remove cluster parameters and miQC model from metadata
+  additional_modalities <- altExpNames(sce)
+  if (length(additional_modalities) == 0) {
+    additional_modalities <- NA
+  }
+  sce$additional_modalities <- paste0(additional_modalities, collapse = ";")
+
+  metadata(sce)$cluster_algorithm <- NULL
+  metadata(sce)$cluster_weighting <- NULL
+  metadata(sce)$cluster_nn <- NULL
+  metadata(sce)$miQC_model <- NULL
+  gc(verbose = FALSE)
+  return(sce)
+}
+
+
+# Read in SCEs -----------------------------------------------------------------
+
+# get list of sces
+sce_list <- purrr::map(input_sce_files, read_trim_sce)
+
+# Add cell type annotation columns where needed  -------------------------------
+
+# check for present cell type annotations
+all_celltypes <- sce_list |>
+  purrr::map(\(sce) {
+    metadata(sce)$celltype_methods
+  }) |>
+  purrr::reduce(union)
+
+
+if ("submitter" %in% all_celltypes) {
+  # Add `"Submitter-excluded"` value to any libraries without submitter
+  sce_list <- sce_list |>
+    purrr::map(\(sce) {
+      if (!"submitter" %in% metadata(sce)$celltype_methods) {
+        colData(sce)$submitter_celltype_annotation <- "Submitter-excluded"
+      }
+      return(sce)
+    })
+}
+if ("singler" %in% all_celltypes) {
+  # Check if the label used for annotation was ontology in at least 1 SCE
+  use_ontology <- sce_list |>
+    purrr::map_lgl(\(sce) {
+      any(metadata(sce)$singler_reference_label == "label.ont")
+    }) |>
+    any()
+
+  # Add `"Cell type annotation not performed"` string to libraries without SingleR
+  sce_list <- sce_list |>
+    purrr::map(\(sce) {
+      if (!"singler" %in% metadata(sce)$celltype_methods) {
+        colData(sce)$singler_celltype_annotation <- "Cell type annotation not performed"
+        if (use_ontology) {
+          colData(sce)$singler_celltype_ontology <- "Cell type annotation not performed"
+        }
+      }
+      return(sce)
+    })
+}
+if ("cellassign" %in% all_celltypes) {
+  # Add `"Cell type annotation not performed"` string to libraries without CellAssign,
+  #  and make the max prediction `NA_real_` for extra safety
+  sce_list <- sce_list |>
+    purrr::map(\(sce){
+      if (!"cellassign" %in% metadata(sce)$celltype_methods) {
+        colData(sce)$cellassign_celltype_annotation <- "Cell type annotation not performed"
+        colData(sce)$cellassign_max_prediction <- NA_real_
+      }
+      return(sce)
+    })
+}
+
+
+# Determine SCE columns to retain  ---------------------------------------------
+
+# Define all possible colData columns which we might want to retain
+possible_columns <- c(
+  "barcodes",
+  # RNA statistics and post-processing
+  "sum",
+  "detected",
+  "total",
+  "subsets_mito_sum",
+  "subsets_mito_detected",
+  "subsets_mito_percent",
+  "miQC_pass",
+  "prob_compromised",
+  "scpca_filter",
+  "additional_modalities",
+  # cell type names
+  "submitter_celltype_annotation",
+  "singler_celltype_annotation",
+  "singler_celltype_ontology",
+  "cellassign_celltype_annotation",
+  "cellassign_max_prediction",
+  # ADT statistics
+  "adt_scpca_filter",
+  "altexps_adt_sum",
+  "altexps_adt_detected",
+  "altexps_adt_percent",
+  # cellhash statistics & demux results
+  "altexps_cellhash_sum",
+  "altexps_cellhash_detected",
+  "altexps_cellhash_percent",
+  "hashedDrops_sampleid",
+  "HTODemux_sampleid",
+  "vireo_sampleid"
+)
+
+# Define colData columns to retain based on intersection with present columns
+present_columns <- sce_list |>
+  purrr::map(\(sce) names(colData(sce))) |>
+  purrr::reduce(union)
+retain_coldata_columns <- intersect(possible_columns, present_columns)
+
+# Define altExp columns to retain/preserve, currently only for "adt"
+adt_possible_columns <- c(
+  "zero.ambient",
+  "high.ambient",
+  "ambient.scale",
+  "sum.controls",
+  "high.controls",
+  "discard"
+)
+adt_present_columns <- sce_list |>
+  # only consider "adt" altExps
+  purrr::keep(\(sce) "adt" %in% altExpNames(sce)) |>
+  purrr::map(\(sce) names(colData(altExp(sce, "adt")))) |>
+  # use .init to handle an empty input; will return the .init value
+  # if input is empty, then there are no "adt" altExps anyways
+  purrr::reduce(union, .init = NULL)
+
+# ensure that there are indeed no "adt" altExps if adt_present_columns is empty
+adt_present <- sce_list |>
+  purrr::map_lgl(\(sce) "adt" %in% altExpNames(sce))
+
+if (is.null(adt_present_columns) && any(adt_present)) {
+  stop("Error in determining which adt altExp columns should be retained.")
+}
+
+retain_altexp_coldata_list <- list("adt" = intersect(adt_possible_columns, adt_present_columns))
+preserve_altexp_rowdata_list <- list("adt" = c("adt_id", "target_type"))
+
+# Merge SCEs -------------------------------------------------------------------
+
+sce_names <- names(sce_list)
+# create combined SCE object
+merged_sce <- scpcaTools::merge_sce_list(
+  sce_list,
+  batch_column = "library_id",
+  cell_id_column = "cell_id",
+  retain_coldata_cols = retain_coldata_columns,
+  include_altexp = any(adt_present),
+  preserve_rowdata_cols = c("gene_symbol", "gene_ids"),
+  retain_altexp_coldata_cols = retain_altexp_coldata_list,
+  preserve_altexp_rowdata_cols = preserve_altexp_rowdata_list
+)
+
+# clean up
+rm(sce_list)
+gc(verbose = FALSE)
+
+# add sample metadata to colData as long as there are no multiplexed data
+if (!opt$multiplexed) {
+  merged_sce <- scpcaTools::metadata_to_coldata(
+    merged_sce,
+    join_columns = "library_id"
+  )
+
+  # remove sample metadata
+  metadata(merged_sce) <- metadata(merged_sce)[names(metadata(merged_sce)) != "sample_metadata"]
+}
+
+# grab technology and EFO from metadata$library_metadata
+library_df <- sce_names |>
+  purrr::map(\(library_id) {
+    lib_meta <- metadata(merged_sce) |>
+      purrr::pluck("library_metadata", library_id)
+    data.frame(
+      library_id = library_id,
+      tech_version = lib_meta$tech_version,
+      assay_ontology_term_id = lib_meta$assay_ontology_term_id,
+      # rename to suspension_type for consistency with merged AnnData objects
+      suspension_type = lib_meta$seq_unit
+    )
+  }) |>
+  dplyr::bind_rows()
+
+# join tech and EFO with colData
+colData(merged_sce) <- colData(merged_sce) |>
+  as.data.frame() |>
+  dplyr::left_join(library_df, by = c("library_id"), relationship = "many-to-one") |>
+  DataFrame(row.names = rownames(colData(merged_sce)))
+
+# HVG selection ----------------------------------------------------------------
+
+# extract the column with the block variable
+batch_column <- merged_sce$library_id
+
+# model gene variance
+gene_var_block <- scran::modelGeneVar(
+  merged_sce,
+  block = batch_column,
+  BPPARAM = bp_param
+)
+# identify subset of variable genes
+hvg_list <- scran::getTopHVGs(
+  gene_var_block,
+  n = opt$n_hvg
+)
+
+metadata(merged_sce)$merged_highly_variable_genes <- hvg_list
+
+# Dim Reduction PCA and UMAP----------------------------------------------------
+
+# multi batch PCA on merged object
+multi_pca <- batchelor::multiBatchPCA(
+  merged_sce,
+  subset.row = hvg_list,
+  batch = batch_column,
+  preserve.single = TRUE,
+  BPPARAM = bp_param
+)
+
+# add PCA results to merged SCE object
+reducedDim(merged_sce, "PCA") <- multi_pca[[1]]
+
+# add UMAP
+merged_sce <- scater::runUMAP(
+  merged_sce,
+  dimred = "PCA",
+  BPPARAM = bp_param
+)
+
+# write out merged sce file
+readr::write_rds(
+  merged_sce,
+  opt$output_sce_file,
+  compress = "gz",
+  compression = 2
+)

--- a/modules/merge-sce/resources/usr/bin/merge_sces.R
+++ b/modules/merge-sce/resources/usr/bin/merge_sces.R
@@ -239,10 +239,11 @@ adt_present_columns <- sce_list |>
   # if input is empty, then there are no "adt" altExps anyways
   purrr::reduce(union, .init = NULL)
 
-# ensure that there are indeed no "adt" altExps if adt_present_columns is empty
+# determine if adt is present for each SCE object
 adt_present <- sce_list |>
   purrr::map_lgl(\(sce) "adt" %in% altExpNames(sce))
 
+# ensure that there are indeed no "adt" altExps if adt_present_columns is empty
 if (is.null(adt_present_columns) && any(adt_present)) {
   stop("Error in determining which adt altExp columns should be retained.")
 }

--- a/modules/merge-sce/resources/usr/bin/move_counts_anndata.py
+++ b/modules/merge-sce/resources/usr/bin/move_counts_anndata.py
@@ -49,6 +49,7 @@ if "logcounts" in object.layers:
     # move logcounts to X and rename
     object.X = object.layers["logcounts"]
     object.uns["X_name"] = "logcounts"
+    del object.layers["logcounts"]
 
     # export object
     object.write_h5ad(args.anndata_file, compression="gzip" if args.compress else None)

--- a/modules/merge-sce/resources/usr/bin/move_counts_anndata.py
+++ b/modules/merge-sce/resources/usr/bin/move_counts_anndata.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# This script takes an AnnData object and checks for the `logcounts`
+# in layers. If present, `logcounts` is moved to `X` and `X` (which has the raw counts)
+# is moved to `raw.X`
+
+import argparse
+import os
+import re
+
+import anndata as adata
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-i",
+    "--anndata_file",
+    dest="anndata_file",
+    required=True,
+    help="Path to HDF5 file with processed AnnData object",
+)
+parser.add_argument(
+    "-u",
+    "--uncompressed",
+    dest="compress",
+    action="store_false",
+    help="Output an uncompressed HDF5 file",
+)
+
+args = parser.parse_args()
+
+# compile extension regex
+file_ext = re.compile(r"\.hdf5$|\.h5$|\.h5ad$", re.IGNORECASE)
+
+# check that input file exists, if it does exist, make sure it's an h5 file
+if not os.path.exists(args.anndata_file):
+    raise FileExistsError("`input_anndata` does not exist.")
+elif not file_ext.search(args.anndata_file):
+    raise ValueError(
+        "--input_anndata must end in either .hdf5, .h5, or .h5ad, and contain a processed AnnData object."
+    )
+
+# read in anndata
+object = adata.read_h5ad(args.anndata_file)
+
+# if logcounts is present
+if "logcounts" in object.layers:
+    # move X to raw.X by creating the raw object
+    object.raw = object
+    # move logcounts to X and rename
+    object.X = object.layers["logcounts"]
+    object.uns["X_name"] = "logcounts"
+
+    # export object
+    object.write_h5ad(args.anndata_file, compression="gzip" if args.compress else None)

--- a/modules/merge-sce/resources/usr/bin/sce_to_anndata.R
+++ b/modules/merge-sce/resources/usr/bin/sce_to_anndata.R
@@ -1,0 +1,213 @@
+#!/usr/bin/env Rscript
+
+# This script takes a SingleCellExperiment stored in a .rds file and converts the main experiment
+# (usually RNA) to an AnnData object saved as an hdf5 file
+
+# The AnnData object being exported by this script is formatted to fit CZI schema: 3.0.0
+
+# import libraries
+suppressPackageStartupMessages({
+  library(optparse)
+  library(SingleCellExperiment)
+})
+
+# set up arguments
+option_list <- list(
+  make_option(
+    opt_str = c("-i", "--input_sce_file"),
+    type = "character",
+    help = "path to rds file with input sce object to be converted"
+  ),
+  make_option(
+    opt_str = c("--output_rna_h5"),
+    type = "character",
+    help = "path to output hdf5 file to store RNA counts as AnnData object. Must end in .hdf5, .h5ad, or .h5"
+  ),
+  make_option(
+    opt_str = c("--feature_name"),
+    type = "character",
+    help = "Feature type. Must match the altExp name, if present."
+  ),
+  make_option(
+    opt_str = c("--output_feature_h5"),
+    type = "character",
+    help = "path to output hdf5 file to store feature counts as AnnData object.
+    Only used if the input SCE contains an altExp. Must end in .hdf5, .h5, or .h5ad"
+  ),
+  make_option(
+    opt_str = c("--compress_output"),
+    action = "store_true",
+    default = FALSE,
+    help = "Compress the H5AD file containing the AnnData object"
+  ),
+  make_option(
+    opt_str = c("--is_merged"),
+    action = "store_true",
+    default = FALSE,
+    help = "Whether the input SCE file contains a merged object"
+  )
+)
+
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# Set up -----------------------------------------------------------------------
+
+# check that filtered SCE file exists
+if (!file.exists(opt$input_sce_file)) {
+  stop(glue::glue("{opt$input_sce_file} does not exist."))
+}
+
+# check that output file is h5
+if (!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5|.h5ad"))) {
+  stop("output rna file name must end in .hdf5, .h5, or .h5ad")
+}
+
+# Merged object function  ------------------------------------------------------
+
+# this function updates merged object formatting for anndata export
+format_merged_sce <- function(sce) {
+  # paste X to any present reduced dim names
+  reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
+  return(sce)
+}
+
+# CZI compliance function ------------------------------------------------------
+
+# this function applies any necessary reformatting or changes needed to make
+# sure that the sce that is getting converted to AnnData is compliant with
+# CZI 3.0.0 requirements: https://github.com/chanzuckerberg/single-cell-curation/blob/b641130fe53b8163e50c39af09ee3fcaa14c5ea7/schema/3.0.0/schema.md
+format_czi <- function(sce) {
+  # add schema version
+  metadata(sce)$schema_version <- "3.0.0"
+
+  # add library_id as an sce colData column
+  # need this column to join in the sample metadata with the colData
+  if (!("library_id" %in% colnames(colData(sce)))) {
+    sce$library_id <- metadata(sce)$library_id
+  }
+
+  # only move sample metadata if not a multiplexed library
+  if (!("cellhash" %in% altExpNames(sce))) {
+    # add sample metadata to colData sce
+    sce <- scpcaTools::metadata_to_coldata(
+      sce,
+      join_columns = "library_id"
+    )
+  }
+
+  # modify colData to be AnnData and CZI compliant
+  coldata_df <- colData(sce) |>
+    as.data.frame() |>
+    dplyr::mutate(
+      # create columns for assay and suspension ontology terms
+      assay_ontology_term_id = metadata(sce)$assay_ontology_term_id,
+      suspension_type = metadata(sce)$seq_unit,
+      # add is_primary_data column; only needed for anndata objects
+      is_primary_data = FALSE
+    )
+
+  # add colData back to sce object
+  colData(sce) <- DataFrame(
+    coldata_df,
+    row.names = rownames(colData(sce))
+  )
+
+  # remove sample metadata from sce metadata, otherwise conflicts with converting object
+  metadata(sce) <- metadata(sce)[names(metadata(sce)) != "sample_metadata"]
+
+  # modify rowData
+  # we don't do any gene filtering between normalized and raw counts matrix
+  # so everything gets set to false
+  rowData(sce)$feature_is_filtered <- FALSE
+
+  # paste X to any present reduced dim names
+  reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
+
+  return(sce)
+}
+
+# MainExp to AnnData -----------------------------------------------------------
+
+# read in sce
+sce <- readr::read_rds(opt$input_sce_file)
+message("sce read")
+
+# if not enough cells to convert, quit and don't do anything
+if (ncol(sce) < 2) {
+  quit(save = "no")
+}
+
+# grab sample metadata
+# we need this if we have any feature data that we need to add it o
+sample_metadata <- metadata(sce)$sample_metadata
+
+# make main sce czi compliant for single objects, or format merged objects
+if (opt$is_merged) {
+  sce <- format_merged_sce(sce)
+} else {
+  sce <- format_czi(sce)
+}
+
+message("Formatting done")
+
+
+
+# export sce as anndata object
+# this function will also remove any R-specific object types from the SCE metadata
+#   before converting to AnnData
+scpcaTools::sce_to_anndata(
+  sce,
+  anndata_file = opt$output_rna_h5,
+  compression = ifelse(opt$compress_output, "gzip", "none")
+)
+
+message("Exported RNA")
+
+# AltExp to AnnData -----------------------------------------------------------
+
+# if feature data exists, grab it and export to AnnData
+if (!is.null(opt$feature_name)) {
+  # make sure the feature data is present
+  if (!(opt$feature_name %in% altExpNames(sce))) {
+    stop("feature_name must match name of altExp in provided SCE object.")
+
+    # if the feature name is cell hash, skip conversion
+  } else if (opt$feature_name == "cellhash") {
+    warning("Conversion of altExp data from multiplexed data is not supported.
+             The altExp will not be converted.")
+
+    # convert altExp
+  } else {
+    # check for output file
+    if (!(stringr::str_ends(opt$output_feature_h5, ".h5ad|.hdf5|.h5"))) {
+      stop("output feature file name must end in .h5ad, .hdf5, or .h5")
+    }
+
+    # extract altExp
+    alt_sce <- altExp(sce, opt$feature_name)
+
+    # only convert altExp with > 1 rows
+    if (nrow(alt_sce) > 1) {
+      # add sample metadata from main sce to alt sce metadata
+      metadata(alt_sce)$sample_metadata <- sample_metadata
+
+      # make sce czi compliant
+      alt_sce <- format_czi(alt_sce)
+      message("alt formatted")
+
+      # export altExp sce as anndata object
+      scpcaTools::sce_to_anndata(
+        alt_sce,
+        anndata_file = opt$output_feature_h5
+      )
+    } else {
+      # warn that the altExp cannot be converted
+      warning(
+        glue::glue("
+          Only 1 row found in altExp named: {opt$feature_name}.
+          This altExp will not be converted to an AnnData object.
+        ")
+      )
+    }
+  }
+}

--- a/modules/merge-sce/resources/usr/bin/sce_to_anndata.R
+++ b/modules/merge-sce/resources/usr/bin/sce_to_anndata.R
@@ -183,7 +183,6 @@ if (opt$feature_name == "cellhash") {
   warning("Conversion of altExp data from multiplexed data is not supported.
              The altExp will not be converted.")
   quit(save = "no")
-  # convert altExp
 }
 
 # check for output file

--- a/modules/merge-sce/resources/usr/bin/sce_to_anndata.R
+++ b/modules/merge-sce/resources/usr/bin/sce_to_anndata.R
@@ -166,7 +166,7 @@ message("Exported RNA")
 # AltExp to AnnData -----------------------------------------------------------
 # end if there is no altExp data or no requested feature
 if (is.null(opt$feature_name) || length(altExpNames(sce)) == 0) {
-  if (opt$feature_name) {
+  if (!is.null(opt$feature_name)) {
     warning("No altExp data to convert.")
   }
   quit(save = "no")

--- a/modules/simulate-sce/main.nf
+++ b/modules/simulate-sce/main.nf
@@ -82,7 +82,7 @@ process permute_bulk{
 
 workflow simulate_sce {
   take:
-    project_ch  // Channel of project names and project directories
+    project_ch  // Channel of [project_id, file(project_dir)]
   main:
     // metadata file for each project: [project_id, metadata_file]
     metadata_ch = project_ch.map{[it[0], it[1] / 'single_cell_metadata.tsv']}

--- a/modules/simulate-sce/main.nf
+++ b/modules/simulate-sce/main.nf
@@ -18,14 +18,14 @@ process permute_metadata {
   output:
     tuple val(project_id), path(permuted_file)
   script:
-    def permuted_file = metadata_file.fileName.name
+    permuted_file = metadata_file.fileName.name
     """
     permute-metadata.R \
       --metadata_file ${metadata_file} \
       --output_file ${permuted_file}
     """
   stub:
-    def permuted_file = metadata_file.fileName.name
+    permuted_file = metadata_file.fileName.name
     """
     touch ${permuted_file}
     """

--- a/modules/simulate-sce/main.nf
+++ b/modules/simulate-sce/main.nf
@@ -11,14 +11,14 @@ process permute_metadata {
   output:
     tuple val(project_id), path(permuted_file)
   script:
-    permuted_file = metadata_file.fileName.name
+    def permuted_file = metadata_file.fileName.name
     """
     permute-metadata.R \
       --metadata_file ${metadata_file} \
       --output_file ${permuted_file}
     """
   stub:
-    permuted_file = metadata_file.fileName.name
+    def permuted_file = metadata_file.fileName.name
     """
     touch ${permuted_file}
     """

--- a/modules/simulate-sce/main.nf
+++ b/modules/simulate-sce/main.nf
@@ -1,3 +1,10 @@
+#!/usr/bin/env nextflow
+
+// Workflow to create simulated/permuted metadata, bulk, and SCE objects
+// for testing OpenSCPCA workflows
+
+
+// module parameters
 params.sim_pubdir = 's3://openscpca-sim-data/test'
 params.simulate_sce_container = 'ccdl/openscpca-simulate-sce:latest'
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,17 +36,19 @@ profiles {
   simulated {
     params {
       release_prefix = "test"
-      release_bucket = "s3://openscpca-sim-data"
+      release_bucket = "s3://openscpca-temp-simdata" // TODO: change to correct simulated data bucket
       results_bucket = "s3://openscpca-sim-workflow-results" // TODO: change to correct output bucket
     }
   }
   stub {
     process.executor = 'local'
     docker.enabled = false
-    params{
+    aws.client.anonymous = true
+    params {
       release_prefix = "test"
-      release_bucket = "s3://openscpca-sim-data"
-      results_bucket = "test/results"
+      release_bucket = "s3://openscpca-temp-simdata" // TODO: change to correct simulated data bucket
+      results_bucket = "test/results" // local output
+      max_memory = 8.GB
     }
   }
   batch {

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,10 +18,9 @@ params {
   results_bucket = "s3://openscpca-nf-workflow-results"
   project = "all"
 
-
   // Resource maximum settings
-  max_cpus = 24
-  max_memory = 96.GB
+  max_cpus = 16
+  max_memory = 128.GB
 }
 
 // Load base process config with labels
@@ -32,6 +31,10 @@ profiles {
     process.executor = 'local'
     docker.enabled = true
     docker.userEmulation = true
+    params {
+      max_cpus = 8
+      max_memory = 32.GB
+    }
   }
   simulated {
     params {
@@ -48,6 +51,7 @@ profiles {
       release_prefix = "test"
       release_bucket = "s3://openscpca-temp-simdata" // TODO: change to correct simulated data bucket
       results_bucket = "test/results" // local output
+      max_cpus = 2
       max_memory = 8.GB
     }
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,9 +13,11 @@ nextflow.enable.moduleBinaries = true
 
 // global parameters for workflows
 params {
+  release_prefix = "2024-05-01"
   release_bucket = "openscpca-data-release"
-  release_prefix = "current"
+  results_bucket = "openscpca-nf-workflow-results"
   project = "all"
+
 
   // Resource maximum settings
   max_cpus = 24

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,8 +14,8 @@ nextflow.enable.moduleBinaries = true
 // global parameters for workflows
 params {
   release_prefix = "2024-05-01"
-  release_bucket = "openscpca-data-release"
-  results_bucket = "openscpca-nf-workflow-results"
+  release_bucket = "s3://openscpca-data-release"
+  results_bucket = "s3://openscpca-nf-workflow-results"
   project = "all"
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,9 +33,21 @@ profiles {
     docker.enabled = true
     docker.userEmulation = true
   }
+  simulated {
+    params {
+      release_prefix = "test"
+      release_bucket = "s3://openscpca-sim-data"
+      results_bucket = "s3://openscpca-sim-workflow-results" // TODO: change to correct output bucket
+    }
+  }
   stub {
     process.executor = 'local'
     docker.enabled = false
+    params{
+      release_prefix = "test"
+      release_bucket = "s3://openscpca-sim-data"
+      results_bucket = "test/results"
+    }
   }
   batch {
     includeConfig 'config/profile_batch.config'

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -1,3 +1,3 @@
 #/bin/bash
 cd /opt/nextflow
-/usr/local/bin/nextflow  -C nextflow.config run main.nf -profile batch
+/usr/local/bin/nextflow  -C nextflow.config run main.nf -profile batch -entry test

--- a/terraform/nextflow-policies.tf
+++ b/terraform/nextflow-policies.tf
@@ -45,7 +45,12 @@ resource "aws_iam_policy" "nf_readwrite_S3" {
           "arn:aws:s3:::openscpca-nf-workflow-results",
           "arn:aws:s3:::openscpca-nf-workflow-results/*",
           "arn:aws:s3:::openscpca-temp-simdata",
-          "arn:aws:s3:::openscpca-temp-simdata/*"
+          "arn:aws:s3:::openscpca-temp-simdata/*",
+          "arn:aws:s3:::openscpca-test-data-release-public-access",
+          "arn:aws:s3:::openscpca-test-data-release-public-access/*",
+          "arn:aws:s3:::openscpca-test-workflow-results-public-access",
+          "arn:aws:s3:::openscpca-test-workflow-results-public-access/*"
+
         ]
         # },
         # {


### PR DESCRIPTION
closes #6 

Here I am adding a module with the `merge_sce` workflow, ported from https://github.com/AlexsLemonade/scpca-nf.

As noted in the readme, I made a few changes along the way.
Most of these were simplify some assumptions and make the workflow work with the input of a list of project folders rather than from a sample sheet. 

One part of this meant that I had to figure out whether the adt was present for each sample, as we use that to determine a few things... I ended up doing this by looking for `_adt.h5ad` files, which seemed the simplest way to make sure we had that information, but I really only use this variable in the AnnData conversion. I probably could have incorporated something to make it work by further modifying the export script, but I did not do that as yet. (I did modify the `merge_sce.R` script to look for ADTs directly, mostly because the script was already doing that in another context.) 

Other than that, things do seem to run as expected. I tested it with `SCPCP000012`, and I am currently testing with `SCPCP000007` to make sure the ADT component works as expected. 

I am filing this as a draft partly because I want to make sure that the changes in progress to enable this workflow more automatically are not interrupted.