### PR TITLE
Use new public buckets

### DIFF
--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -43,7 +43,6 @@ class Utils {
     def process_level = args.process_level ?: "processed"
 
     project_dir = Nextflow.file(project_dir, type: 'dir')
-    println(project_dir)
     process_level = process_level.toLowerCase()
     if (!(process_level in ["raw", "filtered", "processed"])){
       throw new IllegalArgumentException("Unknown process_level '${process_level}'")

--- a/modules/simulate-sce/main.nf
+++ b/modules/simulate-sce/main.nf
@@ -5,7 +5,7 @@
 
 
 // module parameters
-params.sim_pubdir = 's3://openscpca-sim-data/test'
+params.sim_pubdir = 's3://openscpca-test-data-release-public-access/test'
 params.simulate_sce_container = 'ccdl/openscpca-simulate-sce:latest'
 
 process permute_metadata {

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,8 +39,8 @@ profiles {
   simulated {
     params {
       release_prefix = "test"
-      release_bucket = "s3://openscpca-temp-simdata" // TODO: change to correct simulated data bucket
-      results_bucket = "s3://openscpca-sim-workflow-results" // TODO: change to correct output bucket
+      release_bucket = "s3://openscpca-test-data-release-public-access"
+      results_bucket = "s3://openscpca-test-workflow-results-public-access"
     }
   }
   stub {
@@ -49,7 +49,7 @@ profiles {
     aws.client.anonymous = true
     params {
       release_prefix = "test"
-      release_bucket = "s3://openscpca-temp-simdata" // TODO: change to correct simulated data bucket
+      release_bucket = "s3://openscpca-test-data-release-public-access" // test bucket
       results_bucket = "test/results" // local output
       max_cpus = 2
       max_memory = 8.GB


### PR DESCRIPTION
Closes #30

Updates the buckets used by the simulation module and the `simulated` profile to the new public buckets for openscpca.