### PR TITLE
Add upload of logs and reports to S3

### DIFF
--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -1,3 +1,20 @@
 #!/bin/bash
+
+date=$(date "+%Y-%m-%d")
+datetime=$(date "+%Y-%m-%dT%H%M")
+
 cd /opt/nextflow
-nextflow run main.nf -profile batch -entry test
+nextflow run main.nf \
+  -profile batch \
+  -entry test \
+  -with-report ${datetime}_test_report.html \
+  -with-trace  ${datetime}_test_trace.txt
+
+cp .nextflow.log ${datetime}_test.log
+
+# Copy logs to S3 and delete if successful
+aws s3 cp . s3://openscpca-nf-data/logs/${date} \
+  --recursive \
+  --exclude "*" \
+  --include "${datetime}_*" \
+  && rm ${datetime}_*


### PR DESCRIPTION
Closes #36

This PR adds a nextflow html report to the output of running nextflow, and then uploads that to S3 in the same directory as work directories. I am putting the files in subdirectories by date for now, which may not be what we want at the end (maybe by release tag?), but this is a good place to start, I figure.

I tested the connection from the EC2 instance to the S3 work bucket, and everything there seems to be correct with the required permissions for the upload. 

