### PR TITLE
Pull workflow from GitHub in AWS

### DIFF
--- a/.github/workflows/run-batch.yml
+++ b/.github/workflows/run-batch.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags: [v*.*.*]
   workflow_dispatch:
+    inputs:
+      revision:
+        description: "branch or tag to deploy"
+        required: true
+        default: "main"
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -26,9 +31,18 @@ jobs:
           role-session-name: githubActionSession
           aws-region: us-east-1
 
-      - name: Create zip archive
+      - name: Create tmux launch script
+        env:
+          # use the github tag if a push event, or the workflow input if a manual trigger
+          revision: ${{ github.event_name == 'push' && github.ref_name || inputs.revision }}
         run: |
-          zip -r  source.zip  . -x '*. git*'
+          echo '#!/bin/bash' > scripts/tmux_launch.sh
+          echo "GITHUB_TAG=$revision" >> scripts/tmux_launch.sh
+          echo 'tmux new-session -d -s nextflow /opt/nextflow/scripts/run_nextflow.sh' >> scripts/tmux_launch.sh
+
+      - name: Create zip archive of scripts
+        run: |
+          zip -r  source.zip  scripts/
         working-directory: ${{ github.workspace }}
 
       - name: Copy zip to S3

--- a/.github/workflows/run-batch.yml
+++ b/.github/workflows/run-batch.yml
@@ -37,8 +37,9 @@ jobs:
           revision: ${{ github.event_name == 'push' && github.ref_name || inputs.revision }}
         run: |
           echo '#!/bin/bash' > scripts/tmux_launch.sh
-          echo "GITHUB_TAG=$revision" >> scripts/tmux_launch.sh
+          echo "export GITHUB_TAG=$revision" >> scripts/tmux_launch.sh
           echo 'tmux new-session -d -s nextflow /opt/nextflow/scripts/run_nextflow.sh' >> scripts/tmux_launch.sh
+          chmod +x scripts/tmux_launch.sh
 
       - name: Create zip archive of scripts
         run: |

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -8,10 +8,10 @@ date=$(date "+%Y-%m-%d")
 datetime=$(date "+%Y-%m-%dT%H%M")
 
 cd /opt/nextflow
-nextflow pull AlexsLemonade/OpenScPCA-nf -r $GITHUB_TAG
+nextflow pull AlexsLemonade/OpenScPCA-nf -revision $GITHUB_TAG
 
 nextflow run AlexsLemonade/OpenScPCA-nf \
-  -r $GITHUB_TAG \
+  -revision $GITHUB_TAG \
   -profile batch \
   -entry test \
   -with-report ${datetime}_test_report.html \

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
+set -u
+
+GITHUB_TAG=${GITHUB_TAG:-main}
+
 date=$(date "+%Y-%m-%d")
 datetime=$(date "+%Y-%m-%dT%H%M")
 
 cd /opt/nextflow
-nextflow run main.nf \
+nextflow pull AlexsLemonade/OpenScPCA-nf -r $GITHUB_TAG
+
+nextflow run AlexsLemonade/OpenScPCA-nf \
+  -r $GITHUB_TAG \
   -profile batch \
   -entry test \
   -with-report ${datetime}_test_report.html \
@@ -13,7 +20,7 @@ nextflow run main.nf \
 cp .nextflow.log ${datetime}_test.log
 
 # Copy logs to S3 and delete if successful
-aws s3 cp . s3://openscpca-nf-data/logs/${date} \
+aws s3 cp . s3://openscpca-nf-data/logs/test/${date} \
   --recursive \
   --exclude "*" \
   --include "${datetime}_*" \


### PR DESCRIPTION
Closes #35

This is the next step in my methodical testing of changes to the nextflow deployment process.

I am now creating a tmux launch script inline in the GHA and letting Nextflow pull the revisions directly from github based on a revision tag. I set the revision tag as a variable the launch script, which should then be picked up in tmux environment and then the `run_nextflow` script. 

This means we now also only zip up the scripts directory, as the remainder of the repo should not be needed. 