### PR TITLE
34 Allow specification of entrypoints in workflow dispatch

### DIFF
--- a/.github/workflows/run-batch.yml
+++ b/.github/workflows/run-batch.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: Branch or tag to deploy
+        description: Branch or tag of workflow to run
         required: true
         default: main
       run_mode:
@@ -15,6 +15,7 @@ on:
         options:
           - test
           - simulated
+          - scpca
           - full
 
 permissions:
@@ -42,6 +43,7 @@ jobs:
         env:
           # use the github tag if a push event, or the workflow input if a manual trigger
           revision: ${{ github.event_name == 'push' && github.ref_name || inputs.revision }}
+          # default run mode is full for release events, otherwise use the specified mode
           run_mode: ${{ github.event_name == 'push' && 'full' || inputs.run_mode }}
         run: |
           echo '#!/bin/bash' > scripts/tmux_launch.sh

--- a/.github/workflows/run-batch.yml
+++ b/.github/workflows/run-batch.yml
@@ -6,9 +6,16 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: "branch or tag to deploy"
+        description: Branch or tag to deploy
         required: true
-        default: "main"
+        default: main
+      run_mode:
+        description: Workflow run mode
+        type: choice
+        options:
+          - test
+          - simulated
+          - full
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -35,9 +42,11 @@ jobs:
         env:
           # use the github tag if a push event, or the workflow input if a manual trigger
           revision: ${{ github.event_name == 'push' && github.ref_name || inputs.revision }}
+          run_mode: ${{ github.event_name == 'push' && 'full' || inputs.run_mode }}
         run: |
           echo '#!/bin/bash' > scripts/tmux_launch.sh
           echo "export GITHUB_TAG=$revision" >> scripts/tmux_launch.sh
+          echo "export RUN_MODE=$run_mode" >> scripts/tmux_launch.sh
           echo 'tmux new-session -d -s nextflow /opt/nextflow/scripts/run_nextflow.sh' >> scripts/tmux_launch.sh
           chmod +x scripts/tmux_launch.sh
 

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -3,24 +3,61 @@
 set -u
 
 GITHUB_TAG=${GITHUB_TAG:-main}
+RUN_MODE=${RUN_MODE:-test}
 
+profile="batch"
 date=$(date "+%Y-%m-%d")
 datetime=$(date "+%Y-%m-%dT%H%M")
 
 cd /opt/nextflow
 nextflow pull AlexsLemonade/OpenScPCA-nf -revision $GITHUB_TAG
 
+# test mode runs the test workflow only, then exits
+if [ "$RUN_MODE" == "test" ]; then
+  nextflow run AlexsLemonade/OpenScPCA-nf \
+    -revision $GITHUB_TAG \
+    -entry test \
+    -profile $profile \
+    -entry test \
+    -with-report ${datetime}_test_report.html \
+    -with-trace  ${datetime}_test_trace.txt
+
+  cp .nextflow.log ${datetime}_test.log
+
+  # Copy logs to S3 and delete if successful
+  aws s3 cp . s3://openscpca-nf-data/logs/${RUN_MODE}/${date} \
+    --recursive \
+    --exclude "*" \
+    --include "${datetime}_*" \
+    && rm ${datetime}_*
+  exit 0
+fi
+
+# for simulated mode, run the data simulation pipeline first
+if [ "$RUN_MODE" == "simulated" ]; then
+  nextflow run AlexsLemonade/OpenScPCA-nf \
+    -revision $GITHUB_TAG \
+    -entry simulate \
+    -profile $profile \
+    -with-report ${datetime}_simulate_report.html \
+    -with-trace  ${datetime}_simulate_trace.txt
+
+  cp .nextflow.log ${datetime}_simulate.log
+  # set the profile for the next step to use the simulated data
+  profile="${profile},simulated"
+fi
+
+# run the default pipeline
 nextflow run AlexsLemonade/OpenScPCA-nf \
   -revision $GITHUB_TAG \
-  -profile batch \
-  -entry test \
-  -with-report ${datetime}_test_report.html \
-  -with-trace  ${datetime}_test_trace.txt
+  -profile $profile \
+  -with-report ${datetime}_report.html \
+  -with-trace  ${datetime}_trace.txt
 
 cp .nextflow.log ${datetime}_test.log
 
 # Copy logs to S3 and delete if successful
-aws s3 cp . s3://openscpca-nf-data/logs/test/${date} \
+aws s3 cp . s3://openscpca-nf-data/logs/${RUN_MODE}/${date} \
   --recursive \
   --exclude "*" \
   --include "${datetime}_*" \

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -69,7 +69,7 @@ fi
 if [ "$RUN_MODE" == "scpca" ] || [ "$RUN_MODE" == "full" ]; then
   nextflow run AlexsLemonade/OpenScPCA-nf \
     -revision $GITHUB_TAG \
-    -profile profile \
+    -profile $profile \
     -with-report ${datetime}_scpca_report.html \
     -with-trace  ${datetime}_scpca_trace.txt
 

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
-
 set -u
+
+# Run the OpenScPCA Nextflow pipeline with options to specify the run mode
+# Available run modes are:
+#   test:      run the test workflow only
+#   simulated: run the main workflow with simulated data
+#   scpca:     run the main workflow with real data from ScPCA
+#   full:      run the data simulation workflow,
+#              followed by the main pipeline with both simulated and real data
 
 GITHUB_TAG=${GITHUB_TAG:-main}
 RUN_MODE=${RUN_MODE:-test}
@@ -32,8 +39,8 @@ if [ "$RUN_MODE" == "test" ]; then
   exit 0
 fi
 
-# for simulated mode, run the data simulation pipeline first
-if [ "$RUN_MODE" == "simulated" ]; then
+# for full mode, run the data simulation pipeline first
+if [ "$RUN_MODE" == "full" ]; then
   nextflow run AlexsLemonade/OpenScPCA-nf \
     -revision $GITHUB_TAG \
     -entry simulate \
@@ -42,18 +49,32 @@ if [ "$RUN_MODE" == "simulated" ]; then
     -with-trace  ${datetime}_simulate_trace.txt
 
   cp .nextflow.log ${datetime}_simulate.log
-  # set the profile for the next step to use the simulated data
-  profile="${profile},simulated"
 fi
 
-# run the default pipeline
-nextflow run AlexsLemonade/OpenScPCA-nf \
-  -revision $GITHUB_TAG \
-  -profile $profile \
-  -with-report ${datetime}_report.html \
-  -with-trace  ${datetime}_trace.txt
+# if simulated or full, run the main pipeline with simulated data
+if [ "$RUN_MODE" == "simulated" ] || [ "$RUN_MODE" == "full" ]; then
+  nextflow run AlexsLemonade/OpenScPCA-nf \
+    -revision $GITHUB_TAG \
+    -entry main \
+    -profile "${profile},simulated" \
+    -with-report ${datetime}_simulated_report.html \
+    -with-trace  ${datetime}_simulated_trace.txt
 
-cp .nextflow.log ${datetime}_test.log
+  cp .nextflow.log ${datetime}_main.log
+fi
+
+
+
+#if scpca or full, run the main pipeline with real data
+if [ "$RUN_MODE" == "scpca" ] || [ "$RUN_MODE" == "full" ]; then
+  nextflow run AlexsLemonade/OpenScPCA-nf \
+    -revision $GITHUB_TAG \
+    -profile profile \
+    -with-report ${datetime}_scpca_report.html \
+    -with-trace  ${datetime}_scpca_trace.txt
+
+  cp .nextflow.log ${datetime}_scpca.log
+fi
 
 # Copy logs to S3 and delete if successful
 aws s3 cp . s3://openscpca-nf-data/logs/${RUN_MODE}/${date} \

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -18,7 +18,6 @@ if [ "$RUN_MODE" == "test" ]; then
     -revision $GITHUB_TAG \
     -entry test \
     -profile $profile \
-    -entry test \
     -with-report ${datetime}_test_report.html \
     -with-trace  ${datetime}_test_trace.txt
 


### PR DESCRIPTION
closes #34

Here I am adding a dropdown to the workflow menu to allow running the workflow with various entrypoints. 

These are:
-`test`: runs the minimal test workflow which only tests infrastructure, though we could potentially modify this to run other tests in the future...
- `simulated`: runs the simulation workflow first, then runs the main workflow on the simulated data to generate simulated results
- `full` (don't love this name... maybe "release"?): Runs the full workflow with real data.

Some thoughts on reflection, for which I would like input: 
- Maybe I should split off the actual simulation and only run that on request?
- Alternatively, should the "release" or "full" version run twice: once with the simulated data and once with the real? Part of me things that is the right move, as we would almost always want to keep those in sync.

Note that I will include docs for these options in #32

I will not merge this until I have had a chance to test #39, which is currently held up by GHA being "degraded"