### PR TITLE
Fix deploy?

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -14,10 +14,6 @@ permissions:
     group: ec2-user
 
 hooks:
-  BeforeInstall:
-    - location: ./scripts/install_dependencies.sh
-      timeout: 300
-      runas: root
   AfterInstall:
     - location: ./scripts/tmux_launch.sh
       timeout: 300


### PR DESCRIPTION
Apparently I broke something. The deploy seems to be failing at the `beforeInstall` phase, even though I did not do anything to that. But there is nothing really happening in that script, so I just took that hook out of the appspec, and lets see if that fixes things.