### PR TITLE
fix extra entry bug

### DIFF
--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -55,12 +55,11 @@ fi
 if [ "$RUN_MODE" == "simulated" ] || [ "$RUN_MODE" == "full" ]; then
   nextflow run AlexsLemonade/OpenScPCA-nf \
     -revision $GITHUB_TAG \
-    -entry main \
     -profile "${profile},simulated" \
     -with-report ${datetime}_simulated_report.html \
     -with-trace  ${datetime}_simulated_trace.txt
 
-  cp .nextflow.log ${datetime}_main.log
+  cp .nextflow.log ${datetime}_simulated.log
 fi
 
 


### PR DESCRIPTION
The main workflow doesn't use an `-entry` line, but I had one by accident.

I also had a misnamed log file. 

But otherwise the workflow seemed to run fine, with the logs uploaded even on failure, as expected!

It might be nice if there was a way to send an alert when there was a failure, but we can save that for a future enhancement.