### PR TITLE
Use resourceLimits and add test runs

### DIFF
--- a/.github/workflows/nextflow-stub-check.yml
+++ b/.github/workflows/nextflow-stub-check.yml
@@ -18,12 +18,12 @@ jobs:
       - name: Check main workflow
         uses: docker://nextflow/nextflow:24.04.2
         with:
-          args: nextflow run main.nf -stub -profile stub -ansi-log false -log stub-run.log
+          args: nextflow -log stub-run.log run main.nf -stub -profile stub -ansi-log false
 
       - name: Check simulate workflow
         uses: docker://nextflow/nextflow:24.04.2
         with:
-          args: nextflow run main.nf -stub -profile stub -ansi-log false -entry simulate -log simulate-run.log
+          args: nextflow -log simulate-run.log run main.nf -stub -profile stub -ansi-log false -entry simulate
 
       - name: Join log files
         if: ${{ !cancelled() }}

--- a/.github/workflows/nextflow-stub-check.yml
+++ b/.github/workflows/nextflow-stub-check.yml
@@ -11,16 +11,19 @@ on:
 jobs:
   nf-stub-check:
     runs-on: ubuntu-latest
-    container: nextflow/nextflow:24.04.2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Check main workflow
-        run: nextflow run main.nf -stub -profile stub -ansi-log false -log stub-run.log
+        uses: docker://nextflow/nextflow:24.04.2
+        with:
+          args: nextflow run main.nf -stub -profile stub -ansi-log false -log stub-run.log
 
       - name: Check simulate workflow
-        run: nextflow run main.nf -stub -profile stub -entry simulate -ansi-log false -log simulate-run.log
+        uses: docker://nextflow/nextflow:24.04.2
+        with:
+          args: nextflow run main.nf -stub -profile stub -ansi-log false -entry simulate -log simulate-run.log
 
       - name: Join log files
         if: ${{ !cancelled() }}
@@ -28,7 +31,7 @@ jobs:
 
       - name: Upload nextflow log
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nextflow-log
           path: nextflow-runs.log

--- a/.github/workflows/nextflow-stub-check.yml
+++ b/.github/workflows/nextflow-stub-check.yml
@@ -1,0 +1,34 @@
+name: Check nextflow stub
+
+on:
+  push:
+    branches:
+      - jashapiro/resourceLimits
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  nf-stub-check:
+    runs-on: ubuntu-latest
+    container: nextflow/nextflow:24.04.2
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check main workflow
+        run: nextflow run main.nf -stub -profile stub -ansi-log false -log stub-run.log
+
+      - name: Check simulate workflow
+        run: nextflow run main.nf -stub -profile stub -entry simulate -ansi-log false -log simulate-run.log
+
+      - name: Join log files
+        if: ${{ !cancelled() }}
+        run: cat stub-run.log simulate-run.log > nextflow-runs.log
+
+      - name: Upload nextflow log
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: nextflow-log
+          path: nextflow-runs.log

--- a/.github/workflows/nextflow-stub-check.yml
+++ b/.github/workflows/nextflow-stub-check.yml
@@ -1,9 +1,6 @@
 name: Check nextflow stub
 
 on:
-  push:
-    branches:
-      - jashapiro/resourceLimits
   pull_request:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ work/
 
 # ignore test results
 test/results/
+test/simulated/
 
 # ignore hidden `DS_Store`
 .DS_Store

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -1,5 +1,5 @@
 process {
-  memory = {check_memory(4.GB * task.attempt, params.max_memory)}
+  memory = { 4.GB * task.attempt }
 
   maxRetries = 2
   errorStrategy = { if (task.attempt > process.maxRetries) {
@@ -12,47 +12,35 @@ process {
 
 
   withLabel: mem_8 {
-    memory = {check_memory(8.GB * task.attempt, params.max_memory)}
+    memory = { 8.GB * task.attempt }
   }
   withLabel: mem_16 {
-    memory = {check_memory(16.GB * task.attempt, params.max_memory)}
+    memory = { 16.GB * task.attempt }
   }
   withLabel: mem_24 {
-    memory = {check_memory(24.GB * task.attempt, params.max_memory)}
+    memory = { 24.GB * task.attempt }
   }
   withLabel: mem_32 {
-    memory = {check_memory(32.GB * task.attempt, params.max_memory)}
+    memory = { 32.GB * task.attempt }
   }
-  withLabel: mem_max { // max memory for tasks that have failed more than twice for OOM
-    memory = {(task.attempt > 2  && task.exitStatus in 137..140) ? params.max_memory : check_memory(64.GB * task.attempt, params.max_memory)}
+  withLabel: mem_max {
+    // max memory for tasks that have failed more than twice for OOM
+    // set to 2.TB, but will be reduced by process.resourceLimits
+    memory = {(task.attempt > 2  && task.exitStatus in 137..140) ? 2.TB : 64.GB * task.attempt }
   }
   withLabel: cpus_2  {
-    cpus = {check_cpus(2, params.max_cpus)}
+    cpus = 2
   }
   withLabel: cpus_4  {
-    cpus = {check_cpus(4, params.max_cpus)}
+    cpus = 4
   }
   withLabel: cpus_8  {
-    cpus = {check_cpus(8, params.max_cpus)}
+    cpus = 8
   }
   withLabel: cpus_12 {
-    cpus = {check_cpus(12, params.max_cpus)}
+    cpus = 12
   }
   withLabel: cpus_24 {
-    cpus = {check_cpus(24, params.max_cpus)}
+    cpus = 24
   }
-}
-
-
-// Resource check functions
-def check_memory(memory, max_memory) {
-  memory = memory as nextflow.util.MemoryUnit
-  max_memory = max_memory as nextflow.util.MemoryUnit
-  memory < max_memory ? memory : max_memory
-}
-
-def check_cpus(cpus, max_cpus) {
-  cpus = cpus as int
-  max_cpus = max_cpus as int
-  cpus < max_cpus ? cpus : max_cpus
 }

--- a/config/profile_batch.config
+++ b/config/profile_batch.config
@@ -18,15 +18,10 @@ aws {
 process {
   executor = 'awsbatch'
   scratch = false
-
+  resourceLimits = [ cpus: 64, memory: 512.GB ]
   queue = 'openscpca-nf-batch-default-queue'
   // switch to the priority queue for known long running tasks if failing
   withLabel: 'long_running' {
     queue = { task.attempt < 2 ? 'openscpca-nf-batch-default-queue' : 'openscpca-nf-batch-priority-queue' }
   }
-}
-
-params {
-  max_cpus = 64
-  max_memory = 512.GB
 }

--- a/config/profile_old_batch.config
+++ b/config/profile_old_batch.config
@@ -18,5 +18,6 @@ aws{
 process{
   executor = 'awsbatch'
   scratch = false
+  resourceLimits = [ cpus: 64, memory: 512.GB ]
   queue = 'nextflow-batch-default-queue'
 }

--- a/main.nf
+++ b/main.nf
@@ -30,7 +30,7 @@ workflow test {
 }
 
 workflow simulate {
-  project_ids = params.project?.tokenize(',') ?: []
+  project_ids = params.project?.tokenize(';, ') ?: []
   run_all = project_ids.isEmpty() || project_ids[0].toLowerCase() == 'all'
 
   project_ch = Channel.fromPath(Utils.getProjectPaths(release_dir))

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,7 +50,7 @@ profiles {
       release_prefix = "test"
       release_bucket = "s3://openscpca-test-data-release-public-access" // test bucket
       results_bucket = "test/results" // local output
-      projects = "SCPCP000012" // a small project
+      project = "SCPCP000012" // a small project
     }
   }
   batch {

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest {
   mainScript = 'main.nf'
   defaultBranch = 'main'
   version = 'v0.0.1'
-  nextflowVersion = '>=22.10.0'
+  nextflowVersion = '>=24.04.1'
 }
 
 nextflow.enable.moduleBinaries = true
@@ -17,10 +17,6 @@ params {
   release_bucket = "s3://openscpca-data-release"
   results_bucket = "s3://openscpca-nf-workflow-results"
   project = "all"
-
-  // Resource maximum settings
-  max_cpus = 16
-  max_memory = 128.GB
 }
 
 // Load base process config with labels
@@ -28,13 +24,13 @@ includeConfig 'config/process_base.config'
 
 profiles {
   standard {
-    process.executor = 'local'
+    process {
+      executor = 'local'
+      resourceLimits = [ cpus: 4, memory: 16.GB ]
+    }
     docker.enabled = true
     docker.userEmulation = true
-    params {
-      max_cpus = 8
-      max_memory = 32.GB
-    }
+    params.max_memory = 16.GB
   }
   simulated {
     params {
@@ -44,15 +40,16 @@ profiles {
     }
   }
   stub {
-    process.executor = 'local'
+    process {
+      executor = 'local'
+      resourceLimits = [ cpus: 2, memory: 4.GB ]
+    }
     docker.enabled = false
     aws.client.anonymous = true
     params {
       release_prefix = "test"
       release_bucket = "s3://openscpca-test-data-release-public-access" // test bucket
       results_bucket = "test/results" // local output
-      max_cpus = 2
-      max_memory = 8.GB
     }
   }
   batch {

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,6 +50,7 @@ profiles {
       release_prefix = "test"
       release_bucket = "s3://openscpca-test-data-release-public-access" // test bucket
       results_bucket = "test/results" // local output
+      sim_pubdir = "test/simulated" // local output
       project = "SCPCP000012" // a small project
     }
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest {
   mainScript = 'main.nf'
   defaultBranch = 'main'
   version = 'v0.0.1'
-  nextflowVersion = '>=24.04.1'
+  nextflowVersion = '>=24.04.0'
 }
 
 nextflow.enable.moduleBinaries = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,6 +50,7 @@ profiles {
       release_prefix = "test"
       release_bucket = "s3://openscpca-test-data-release-public-access" // test bucket
       results_bucket = "test/results" // local output
+      projects = "SCPCP000012" // a small project
     }
   }
   batch {

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,7 +30,6 @@ profiles {
     }
     docker.enabled = true
     docker.userEmulation = true
-    params.max_memory = 16.GB
   }
   simulated {
     params {


### PR DESCRIPTION
This started with just changing to using the new `process.resourceLimits` to replace our functions for checking memory and cpus against the maximum allowances. 

One thing that was a bit non-obvious was how to handle the `mem_max` label: I ended up just picking a memory amount larger than any max value we are likely to use in the directive, but this is automatically scaled down to whatever is set in the `process.resourceLimits` setting. 

The one disadvantage of this setup is that it is a bit harder to change limits on the fly; you can't just set a `param` and have that propagate in as we had before, but I don't expect that to be a common use case.

After I added the resourceLimits changes, I thought this was a good chance to add some more testing, so I included a new GitHub action for stub runs of the workflow. 