### PR TITLE
49 Add filtering to merge module to exclude known failures

### DIFF
--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -5,7 +5,7 @@
 
 // module parameters
 params.reuse_merge = false
-params.max_libraries = 75 // maximum number of libraries to merge (current number is a guess, based on 59 working, but 104 not)
+params.max_merge_libraries = 75 // maximum number of libraries to merge (current number is a guess, based on 59 working, but 104 not)
 params.num_hvg = 2000 // number of HVGs to select
 
 // merge workflow variables
@@ -134,7 +134,7 @@ workflow merge_sce {
       }
       .branch{
         // check the number of libraries
-        mergeable: it[1].size() < params.max_libraries
+        mergeable: it[1].size() < params.max_merge_libraries
         oversized: true
       }
 

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -5,6 +5,7 @@
 
 // module parameters
 params.reuse_merge = false
+params.max_libraries = 75 // maximum number of libraries to merge (current number is a guess, based on 59 working, but 104 not)
 params.num_hvg = 2000 // number of HVGs to select
 
 // merge workflow variables
@@ -132,8 +133,8 @@ workflow merge_sce {
         return [project_id, library_ids, processed_files]
       }
       .branch{
-        // only merge projects with fewer than 75 libraries (this is a guess... we know we can do 59 but not 104)
-        mergeable: it[1].size() < 75
+        // check the number of libraries
+        mergeable: it[1].size() < params.max_libraries
         oversized: true
       }
 


### PR DESCRIPTION
Closes #49

To reduce computation for the merge workflow a bit when we expect it to fail, I am here adding a parameter for the maximum number of libraries to merge.

I guessed on the max to be between the failure and success, but as it is a parameter it should be easy to test higher numbers if we get libraries near the boundary.