### PR TITLE
Use samples as principal workflow elements

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -33,8 +33,7 @@ workflow simulate {
   project_ids = params.project?.tokenize(';, ') ?: []
   run_all = project_ids.isEmpty() || project_ids[0].toLowerCase() == 'all'
 
-  project_ch = Channel.fromPath(Utils.getProjectPaths(release_dir))
-    .map{[it.name, it]} // name is the directory name, which will be SCPCP000000 format
+  project_ch = Channel.fromList(Utils.getProjectTuples(release_dir))
     .filter{ run_all || it[0] in project_ids }
   simulate_sce(project_ch)
 }
@@ -44,10 +43,9 @@ workflow {
   project_ids = params.project?.tokenize(';, ') ?: []
   run_all = project_ids.isEmpty() || project_ids[0].toLowerCase() == 'all'
 
-  // project channel of [project_id, project_path]
-  project_ch = Channel.fromPath(Utils.getProjectPaths(release_dir))
-    .map{[it.name, it]} // name is the directory name, which will be SCPCP000000 format
-    .filter{ run_all || it[0] in project_ids }
+  // sample channel of [sample_id, project_id, sample_path]
+  sample_ch = Channel.fromList(Utils.getSampleTuples(release_dir))
+    .filter{ run_all || it[1] in project_ids }
 
-  merge_sce(project_ch)
+  merge_sce(sample_ch)
 }

--- a/modules/example/main.nf
+++ b/modules/example/main.nf
@@ -11,7 +11,7 @@ process say_hello{
 }
 
 workflow example {
-  names_ch = Channel.from(["Alex", "World"])
+  names_ch = Channel.fromList(["Alex", "World"])
   say_hello(names_ch).subscribe{
     log.info(it.getText())
   }

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -118,9 +118,8 @@ workflow merge_sce {
   main:
     // create a channel of [project_id, file(project_dir)] with one per project
     project_ch = sample_ch
-      .map{it[1]} // project_ids
+      .map{[it[1], it[2].parent]} // parent of the sample_dir is the project_dir
       .unique()
-      .map{[it, file("${params.results_bucket}/${params.release_prefix}/${it}", type: "dir")]}
 
     project_branch = project_ch
       .branch{

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -114,8 +114,13 @@ process export_anndata {
 
 workflow merge_sce {
   take:
-    project_ch  // Channel of [project_id, file(project_dir)]
+    sample_ch  // Channel of [sample_id, project_id, file(sample_dir)]
   main:
+    // create a channel of [project_id, file(project_dir)] with one per project
+    project_ch = sample_ch
+      .map{it[1]} // project_ids
+      .unique()
+      .map{[it, file("${params.results_bucket}/${params.release_prefix}/${it}", type: "dir")]}
 
     project_branch = project_ch
       .branch{
@@ -128,7 +133,7 @@ workflow merge_sce {
     // this will be a channel of [project_id, [library_ids], [processed_sce_files]]
     libraries_ch = project_branch.single_sample
       .map{ project_id, project_dir ->
-        def processed_files = Utils.getProjectFiles(project_dir, format: "sce", process_level: "processed")
+        def processed_files = Utils.getLibraryFiles(project_dir, format: "sce", process_level: "processed")
         def library_ids = processed_files.collect{it.name.replace('_processed.rds', '')}
         return [project_id, library_ids, processed_files]
       }
@@ -150,7 +155,7 @@ workflow merge_sce {
 
     libraries_branch = libraries_ch.mergeable
       .branch{
-        has_merge: file("${publish_merge_base}/${it[0]}/${it[0]}_merged.rds").exists() && params.reuse_merge
+        has_merge: params.reuse_merge && file("${publish_merge_base}/${it[0]}/${it[0]}_merged.rds").exists()
         make_merge: true
       }
 


### PR DESCRIPTION
Here I am changing the inputs to the merge workflow to take a channel of samples rather than a channel of projects.

This reflects the discussion in #29 about what the "standard" input to a module should be. In this case it doesn't matter much, as the sample channel is condensed down to the former project channel, but this presents an example of how this might be done in the future. 

I also added/modified a few of the `Util` functions to return lists of tuples that can be converted to channels with the `fromList()` factory method, rather than having to build the channels from the paths as before.

I left the input for the simulation script alone, partly just to minimize changes, and partly to show that either might be possible as we proceed to add modules in the future.
