### PR TITLE
Add data release as workflow dispatch option

### DIFF
--- a/.github/workflows/run-batch.yml
+++ b/.github/workflows/run-batch.yml
@@ -1,4 +1,4 @@
-name: Batch CodeDeploy CI
+name: Run Workflow on AWS Batch
 
 on:
   push:
@@ -9,6 +9,10 @@ on:
         description: Branch or tag of workflow to run
         required: true
         default: main
+      data_release:
+        description: Data release date
+        required: true
+        default: default
       run_mode:
         description: Workflow run mode
         type: choice
@@ -50,6 +54,8 @@ jobs:
         env:
           # use the github tag if a push event, or the workflow input if a manual trigger
           revision: ${{ github.event_name == 'push' && github.ref_name || inputs.revision }}
+          # default data release for release events specified, otherwise use the specified data release
+          data_release: ${{ github.event_name == 'push' && 'default' || inputs.data_release }}
           # default run mode is full for release events, otherwise use the specified mode
           run_mode: ${{ github.event_name == 'push' && 'full' || inputs.run_mode }}
           # default output mode is prod for release events, otherwise use the specified mode
@@ -57,6 +63,7 @@ jobs:
         run: |
           echo '#!/bin/bash' > scripts/tmux_launch.sh
           echo "export GITHUB_TAG=$revision" >> scripts/tmux_launch.sh
+          echo "export DATA_RELEASE=$data_release" >> scripts/tmux_launch.sh
           echo "export RUN_MODE=$run_mode" >> scripts/tmux_launch.sh
           echo "export OUTPUT_MODE=$output_mode" >> scripts/tmux_launch.sh
           echo 'tmux new-session -d -s nextflow /opt/nextflow/scripts/run_nextflow.sh' >> scripts/tmux_launch.sh

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "Installing Dependencies and unzip"
-chown ec2-user /opt/nextflow

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -14,9 +14,9 @@ set -u
 # DATA_RELEASE is the date of the data release to use, in YYYY-MM-DD format, or `default`.
 
 GITHUB_TAG=${GITHUB_TAG:-main}
+DATA_RELEASE=${DATA_RELEASE:-default}
 RUN_MODE=${RUN_MODE:-test}
 OUTPUT_MODE=${OUTPUT_MODE:-staging}
-DATA_RELEASE=${DATA_RELEASE:-default}
 
 date=$(date "+%Y-%m-%d")
 datetime=$(date "+%Y-%m-%dT%H%M")
@@ -66,7 +66,14 @@ fi
 # Set the release_prefix param if data release is not default
 $release_param=""
 if [ "$DATA_RELEASE" != "default" ]; then
-  release_param="--release_prefix $DATA_RELEASE"
+  # check release is valid
+  if [ "$(aws s3 ls s3://openscpca-data-release/${DATA_RELEASE})" ]; then
+    release_param="--release_prefix $DATA_RELEASE"
+  else
+    echo "Data release $DATA_RELEASE not found in S3" >> run_errors.log
+    slack_error run_errors.log
+    exit 1
+  fi
 fi
 
 

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -70,15 +70,18 @@ if [ "$DATA_RELEASE" != "default" ]; then
   if [ "$(aws s3 ls s3://openscpca-data-release/${DATA_RELEASE})" ]; then
     release_param="--release_prefix $DATA_RELEASE"
   else
-    echo "Data release $DATA_RELEASE not found in S3" >> run_errors.log
-    slack_error run_errors.log
-    exit 1
+    echo "Data release `$DATA_RELEASE` not found in S3" >> run_errors.log
   fi
 fi
 
-
 nextflow pull AlexsLemonade/OpenScPCA-nf -revision $GITHUB_TAG \
-|| echo "Error pulling OpenScPCA-nf workflow" >> run_errors.log
+|| echo "Error pulling OpenScPCA-nf workflow with revision `$GITHUB_TAG`" >> run_errors.log
+
+# post any errors from from data release and workflow pull and exit
+if [ -s run_errors.log ]; then
+  slack_error run_errors.log
+  exit 1
+fi
 
 # test mode runs the test workflow only, then exits
 if [ "$RUN_MODE" == "test" ]; then


### PR DESCRIPTION
Closes #60

Since the primary method of running the openscpca-nf workflow will be via workflow dispatch, I wanted to add the ability to specify a data release to the options there, so this PR does that. In particular, we may want to run on "future" releases during the process of preparing a new data release.

As with other arguments, the value is passed along via setting an environment variable in the tmux launch script before sending it to AWS.

The release is only used for the `simulate` entrypoint or when running the rest of the workflow with real data, to prevent overwriting the prefix for test data.

I also added a check that the release prefix is valid, so we don't waste time trying to launch a workflow when the input directory  doesn't exist. If that and/or the nextflow pull fails, we report the error and exit.
