### PR TITLE
Data release version update 

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -13,7 +13,7 @@ nextflow.enable.moduleBinaries = true
 
 // global default parameters for workflows: output buckets are set to staging by default
 params {
-  release_prefix = "2024-07-05"
+  release_prefix = "2024-07-08"
   release_bucket = "s3://openscpca-data-release"
   results_bucket = "s3://openscpca-nf-workflow-results-staging"
   sim_bucket = "s3://openscpca-test-data-release-staging"

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,7 +13,7 @@ nextflow.enable.moduleBinaries = true
 
 // global default parameters for workflows: output buckets are set to staging by default
 params {
-  release_prefix = "2024-05-01"
+  release_prefix = "2024-07-05"
   release_bucket = "s3://openscpca-data-release"
   results_bucket = "s3://openscpca-nf-workflow-results-staging"
   sim_bucket = "s3://openscpca-test-data-release-staging"


### PR DESCRIPTION
As part of https://github.com/AlexsLemonade/OpenScPCA-admin/issues/212, I am here updating the default data release for the workflow to the most recent data. At the moment this data is still being uploaded to S3, but I will not merge until that is complete. 