### PR TITLE
fix undefined variable in launch script

### DIFF
--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -64,7 +64,7 @@ if [ "$OUTPUT_MODE" == "prod" ]; then
 fi
 
 # Set the release_prefix param if data release is not default
-$release_param=""
+release_param=""
 if [ "$DATA_RELEASE" != "default" ]; then
   # check release is valid
   if [ "$(aws s3 ls s3://openscpca-data-release/${DATA_RELEASE})" ]; then

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -162,7 +162,7 @@ aws s3 cp . s3://openscpca-nf-data/logs/${RUN_MODE}/${date} \
   --recursive \
   --exclude "*" \
   --include "${datetime}_*" \
-  && rm ${datetime}_*
+  && rm ${datetime}_* \
   || echo "Error copying logs to S3" >> run_errors.log
 
 # Post any errors to slack


### PR DESCRIPTION
Does the thing it says. Accidentally had an extra `$` which caused failure.

Hopefully addresses #64, but I am not declaring victory yet.