### PR TITLE
Fix S3 upload error

### DIFF
--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -165,7 +165,7 @@ aws s3 cp . "s3://openscpca-nf-data/logs/${RUN_MODE}/${date}" \
   --recursive \
   --exclude "*" \
   --include "${datetime}_*" \
-  && rm "${datetime}_*" \
+  && rm ${datetime}_* \
   || echo "Error copying logs to S3" >> run_errors.log
 
 # Post any errors to slack


### PR DESCRIPTION
The S3 upload error we were seeing in slack was not actually an upload error, but rather an error in the `rm` step. The log files were being uploaded as expected to S3, but I had erroneously added matching quotes around the glob going into `rm` so it was not being expanded and did not match any files.

