### PR TITLE
Increase default memory for run_scdblfinder

### DIFF
--- a/modules/doublet-detection/main.nf
+++ b/modules/doublet-detection/main.nf
@@ -7,6 +7,7 @@ params.doublet_detection_container = 'public.ecr.aws/openscpca/doublet-detection
 process run_scdblfinder {
   container params.doublet_detection_container
   tag "${sample_id}"
+  label 'mem_8'
   publishDir "${params.results_bucket}/${params.release_prefix}/doublet-detection/${project_id}/${sample_id}", mode: 'copy'
   input:
     tuple val(sample_id),


### PR DESCRIPTION
We were getting a lot of failures for out of memory errors for `run_scdblfinder`, so let's bump up the default memory to 8 GB.