### PR TITLE
Prepare for v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Add new release notes in reverse numerical order (newest first) below this comme
 You may want to add temporary notes here for tracking as features are added, before a new release is ready.
 -->
 
+## v0.1.1
+
+- Increase default memory for scDblFinder processes
+
 ## v0.1.0
 
 - Initial versioned release of the `OpenScPCA-nf` Nextflow workflow

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
   homePage = 'https://github.com/AlexsLemonade/openScPCA-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.1.0'
+  version = 'v0.1.1'
   nextflowVersion = '>=24.04.0'
 }
 


### PR DESCRIPTION
Part of #83
This is a very small release, just increasing the the default memory for scDblFinder. 

I would not have put this in its own release  except for the fact that the previous run failed due to an AWS/Docker pull error. 