### PR TITLE
Update default release for august data release

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ nextflow.enable.moduleBinaries = true
 
 // global default parameters for workflows: output buckets are set to staging by default
 params {
-  release_prefix = "2024-07-08"
+  release_prefix = "2024-08-22"
   release_bucket = "s3://openscpca-data-release"
   results_bucket = "s3://openscpca-nf-workflow-results-staging"
   sim_bucket = "s3://openscpca-test-data-release-staging"


### PR DESCRIPTION
Part of https://github.com/AlexsLemonade/OpenScPCA-admin/issues/244

This PR is to update the default release prefix for the OpenScPCA-nf workflow to the latest data release, which will be dated `2024-08-22`, one week from today, to allow for time to run the workflow (and fix any bugs that might pop up related to file format changes 🤞🏼)



