### PR TITLE
Add nextflow -resume setup on workflow runs

### DIFF
--- a/.github/workflows/run-batch.yml
+++ b/.github/workflows/run-batch.yml
@@ -30,6 +30,10 @@ on:
         options:
           - staging
           - prod
+      resume:
+        description: Use -resume flag for Nextflow launch
+        type: boolean
+        default: true
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -62,12 +66,14 @@ jobs:
           run_mode: ${{ github.event_name == 'push' && 'full' || inputs.run_mode }}
           # default output mode is prod for release events, otherwise use the specified mode
           output_mode: ${{ github.event_name == 'push' && 'prod' || inputs.output_mode }}
+          resume: ${{ github.event_name == 'push' && 'true' || inputs.resume }}
         run: |
           echo '#!/bin/bash' > scripts/tmux_launch.sh
           echo "export GITHUB_TAG=$revision" >> scripts/tmux_launch.sh
           echo "export DATA_RELEASE=$data_release" >> scripts/tmux_launch.sh
           echo "export RUN_MODE=$run_mode" >> scripts/tmux_launch.sh
           echo "export OUTPUT_MODE=$output_mode" >> scripts/tmux_launch.sh
+          echo "export RESUME=$resume" >> scripts/tmux_launch.sh
           echo 'tmux new-session -d -s nextflow /opt/nextflow/scripts/run_nextflow.sh' >> scripts/tmux_launch.sh
           chmod +x scripts/tmux_launch.sh
 

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -17,6 +17,7 @@ GITHUB_TAG=${GITHUB_TAG:-main}
 DATA_RELEASE=${DATA_RELEASE:-default}
 RUN_MODE=${RUN_MODE:-test}
 OUTPUT_MODE=${OUTPUT_MODE:-staging}
+RESUME=${RESUME:-false}
 
 date=$(date "+%Y-%m-%d")
 datetime=$(date "+%Y-%m-%dT%H%M")
@@ -77,6 +78,12 @@ if [ "$DATA_RELEASE" != "default" ]; then
   fi
 fi
 
+if [ "$RESUME" == "true" ]; then
+  resume_flag="-resume"
+else
+  resume_flag=""
+fi
+
 nextflow pull AlexsLemonade/OpenScPCA-nf -revision $GITHUB_TAG \
 || echo "Error pulling OpenScPCA-nf workflow with revision '$GITHUB_TAG'" >> run_errors.log
 
@@ -129,6 +136,7 @@ if [ "$RUN_MODE" == "full" ]; then
     -with-trace  "${datetime}_simulate_trace.txt" \
     -with-tower \
     $release_param \
+    $resume_flag \
     || echo "Error with simulate run" >> run_errors.log
 
   cp .nextflow.log "${datetime}_simulate.log"
@@ -142,6 +150,7 @@ if [ "$RUN_MODE" == "simulated" ] || [ "$RUN_MODE" == "full" ]; then
     -with-report "${datetime}_simulated_report.html" \
     -with-trace  "${datetime}_simulated_trace.txt" \
     -with-tower \
+    $resume_flag \
     || echo "Error with simulated data run" >> run_errors.log
 
   cp .nextflow.log "${datetime}_simulated.log"
@@ -158,6 +167,7 @@ if [ "$RUN_MODE" == "scpca" ] || [ "$RUN_MODE" == "full" ]; then
     -with-trace  "${datetime}_scpca_trace.txt" \
     -with-tower \
     $release_param \
+    $resume_flag \
     || echo "Error with scpca data run" >> run_errors.log
 
   cp .nextflow.log "${datetime}_scpca.log"

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -135,8 +135,8 @@ if [ "$RUN_MODE" == "full" ]; then
     -with-report "${datetime}_simulate_report.html" \
     -with-trace  "${datetime}_simulate_trace.txt" \
     -with-tower \
-    $release_param \
     $resume_flag \
+    $release_param \
     || echo "Error with simulate run" >> run_errors.log
 
   cp .nextflow.log "${datetime}_simulate.log"
@@ -166,8 +166,8 @@ if [ "$RUN_MODE" == "scpca" ] || [ "$RUN_MODE" == "full" ]; then
     -with-report "${datetime}_scpca_report.html" \
     -with-trace  "${datetime}_scpca_trace.txt" \
     -with-tower \
-    $release_param \
     $resume_flag \
+    $release_param \
     || echo "Error with scpca data run" >> run_errors.log
 
   cp .nextflow.log "${datetime}_scpca.log"


### PR DESCRIPTION
Closes #92

Here I am adding the option to use the `-resume` flag with the Nextflow runs. It should be set as an option on manual runs, but I am actually setting it by default in the automated deploy runs, which I think should be fine, but if it turns out to be a problem, we can always turn it off there as well. 