### PR TITLE
Minor updates to configs for local & batch

### DIFF
--- a/config/profile_batch.config
+++ b/config/profile_batch.config
@@ -5,7 +5,6 @@ docker.enabled = true
 wave.enabled = true
 fusion.enabled = true
 
-
 aws {
   batch{
     maxTransferAttempts = 3
@@ -14,10 +13,8 @@ aws {
   region = 'us-east-2'
 }
 
-
 process {
   executor = 'awsbatch'
-  scratch = false
   resourceLimits = [ cpus: 64, memory: 512.GB ]
   queue = 'openscpca-nf-batch-default-queue'
   // switch to the priority queue for known long running tasks if failing

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,7 +32,6 @@ profiles {
     }
     docker.enabled = true
     docker.runOptions = '--platform linux/amd64'
-    wave.enabled = true
   }
   prod {
     params {

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,7 +31,8 @@ profiles {
       resourceLimits = [ cpus: 4, memory: 16.GB ]
     }
     docker.enabled = true
-    docker.userEmulation = true
+    docker.runOptions = '--platform linux/amd64'
+    wave.enabled = true
   }
   prod {
     params {


### PR DESCRIPTION
As described in https://github.com/AlexsLemonade/OpenScPCA-nf/issues/85#issuecomment-2341765247, I discovered a few small setting changes while testing why we were getting errors pulling containers, and I am adding them here:

The first is the removal of `scratch = false` in favor of the default setting. I think that we had originally set this to accommodate the use of a dynamically expanding volume which did not include the scratch directory in `scpca-nf`, but with the `fusion` file system this should not be needed.

The other change is to make the local run use the correct platform on Apple Silicon and remove a deprecated option.

When this PR goes in, I will run another test to see if #85 seems to really be resolved.