### PR TITLE
Updates for release 0.1.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=200"]
@@ -13,7 +13,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.4
+    rev: v8.21.2
     hooks:
       - id: gitleaks
   - repo: local
@@ -24,15 +24,15 @@ repos:
         language: fail
         files: "(conda-meta|pyvenv.cfg|renv/library)"
   - repo: https://github.com/crate-ci/typos
-    rev: v1.22.9
+    rev: typos-dict-v0.11.34
     hooks:
       - id: typos
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.0
+    rev: v0.7.2
     hooks:
       - id: ruff-format
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.2
+    rev: v0.4.3.9003
     hooks:
       - id: style-files
       - id: parsable-R

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Add new release notes in reverse numerical order (newest first) below this comme
 You may want to add temporary notes here for tracking as features are added, before a new release is ready.
 -->
 
+## v0.1.2
+
+- Update scpcaTools images to v0.4.1 versions
+- update simulations to match current (v0.8.5) `scpca-nf`  output
+  - Change reduced dimension names in AnnData output (to `X_pca` and `X_umap`)
+  - Use new age columns
+- Centralized docker image definitions in `config/containers.config`
+- Added initial documentation about porting modules
+
 ## v0.1.1
 
 - Increase default memory for scDblFinder processes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You may want to add temporary notes here for tracking as features are added, bef
 ## v0.1.2
 
 - Update scpcaTools images to v0.4.1 versions
-- update simulations to match current (v0.8.5) `scpca-nf`  output
+- Update simulations to match current (v0.8.5) `scpca-nf` output
   - Change reduced dimension names in AnnData output (to `X_pca` and `X_umap`)
   - Use new age columns
 - Centralized docker image definitions in `config/containers.config`

--- a/config/containers.config
+++ b/config/containers.config
@@ -5,9 +5,9 @@ params{
   python_container = 'python:3.11'
 
   // scpcaTools containers (used by `merge-sce` module)
-  scpcatools_slim_container = 'ghcr.io/alexslemonade/scpcatools-slim:v0.4.0'
-  scpcatools_reports_container = 'ghcr.io/alexslemonade/scpcatools-reports:v0.4.0'
-  scpcatools_anndata_container = "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.0"
+  scpcatools_slim_container = 'ghcr.io/alexslemonade/scpcatools-slim:v0.4.1'
+  scpcatools_reports_container = 'ghcr.io/alexslemonade/scpcatools-reports:v0.4.1'
+  scpcatools_anndata_container = "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.1"
 
   // simulate-sce module
   simulate_sce_container = 'public.ecr.aws/openscpca/simulate-sce:v0.1.0'

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
   homePage = 'https://github.com/AlexsLemonade/openScPCA-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.1.1'
+  version = 'v0.1.2'
   nextflowVersion = '>=24.04.0'
 }
 


### PR DESCRIPTION
Part of #97

These are minor updates to change the version numbers and add release notes, but while we were at it I thought I should update the scpcaTools images as well. 

