### PR TITLE
Update metadata to include project-specific fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You may want to add temporary notes here for tracking as features are added, bef
 - Update simulations to match current (v0.8.5) `scpca-nf` output
   - Change reduced dimension names in AnnData output (to `X_pca` and `X_umap`) and updated formatting to match scpca-nf v0.8.5
   - Use new age columns
+  - Metadata for simulated data now includes project-specific fields
 - Centralized docker image definitions in `config/containers.config`
 - Added initial documentation about porting modules
 

--- a/modules/simulate-sce/readme.md
+++ b/modules/simulate-sce/readme.md
@@ -4,4 +4,4 @@ This workflow is designed to simulate single cell data, primarily using the [spl
 
 Scripts are derived from the the `simulate-sce` module of the [OpenScPCA-analysis](https://github.com/AlexsLemonade/OpenScPCA-analysis) repository.
 
-Permalink to the version used: https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/c903e51fe18f0e048ced9a4978bcf056f3f78999/analyses/simulate-sce
+Permalink to the version used: https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/f7732265ea493f3281d789a84fa250222a819ff1/analyses/simulate-sce

--- a/modules/simulate-sce/resources/usr/bin/permute-metadata.R
+++ b/modules/simulate-sce/resources/usr/bin/permute-metadata.R
@@ -46,6 +46,9 @@ library_fields <- c(
   "seq_unit",
   "technology",
   "filtered_cell_count",
+  "filtered_spots",
+  "unfiltered_spots",
+  "tissue_spots",
   "submitter",
   "pi_name",
   "project_title"
@@ -81,7 +84,9 @@ processing_fields <- c(
   "genome_assembly",
   "has_cellhash",
   "includes_anndata",
+  "is_cell_line",
   "is_multiplexed",
+  "is_xenograft",
   "has_citeseq",
   "adt_filtering_method",
   "adt_normalization_method",
@@ -92,6 +97,7 @@ processing_fields <- c(
   "prob_compromised_cutoff",
   "processed_cells",
   "salmon_version",
+  "spaceranger_version",
   "total_reads",
   "transcript_type",
   "unfiltered_cells",
@@ -100,15 +106,17 @@ processing_fields <- c(
   "workflow_version"
 )
 
-# Remove project-specific columns
-match_cols <- sort(match(c(library_fields, sample_fields, processing_fields), colnames(metadata)))
-metadata <- metadata[, match_cols]
+# get project-specific columns, which should also be sample-specific
+project_fields <- setdiff(colnames(metadata), c(library_fields, sample_fields, processing_fields))
 
 # get sample metadata only & reduce to one line per sample
-sample_metadata <- metadata[, sample_fields] |> dplyr::distinct()
+sample_metadata <- metadata[, c(sample_fields, project_fields)] |> dplyr::distinct()
 
 # check that sample data are not repeated
-stopifnot(length(unique(sample_metadata$scpca_sample_id)) == nrow(sample_metadata))
+stopifnot(
+  "Sample data seem to be repeated, metadata permutation failed" =
+    length(unique(sample_metadata$scpca_sample_id)) == nrow(sample_metadata)
+)
 
 # permute sample metadata -------------------------------------------------------------
 diagnosis_order <- sample(seq(1, nrow(sample_metadata)), nrow(sample_metadata))
@@ -129,6 +137,11 @@ sample_metadata <- sample_metadata |>
     participant_id = paste0("P", forcats::fct_anon(participant_id)), # anonymize participant_id
     submitter_id = "" # remove submitter_id,
   )
+
+# permute project-specific columns
+for (f in project_fields) {
+  sample_metadata[[f]] <- sample(sample_metadata[[f]])
+}
 
 metadata <- metadata |>
   dplyr::rows_update(sample_metadata, by = "scpca_sample_id")

--- a/modules/simulate-sce/resources/usr/bin/reformat_anndata.py
+++ b/modules/simulate-sce/resources/usr/bin/reformat_anndata.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-d",
         "--dir",
-        help="directory containing H5AD files and PCA metadaa",
+        help="directory containing H5AD files and PCA metadata",
         required=True,
     )
 


### PR DESCRIPTION
Here I am porting over the changes from https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/879 that update the simulated metadata files to include project-specific fields. I also updated the readme to reflect the new script source commit and the CHANGELOG to mention these changes.

closes #101