### PR TITLE
Update default release date to 2024-11-25

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ nextflow.enable.moduleBinaries = true
 
 // global default parameters for workflows: output buckets are set to staging by default
 params {
-  release_prefix = "2024-08-22"
+  release_prefix = "2024-11-25"
   release_bucket = "s3://openscpca-data-release"
   results_bucket = "s3://openscpca-nf-workflow-results-staging"
   sim_bucket = "s3://openscpca-test-data-release-staging"


### PR DESCRIPTION
As part of https://github.com/AlexsLemonade/OpenScPCA-admin/issues/286, I am here updating the default release date for the OpenScPCA-nf workflow. There should be no other code changes. 
