### PR TITLE
Update simulate-sce to handle zero-size droplets

### DIFF
--- a/modules/simulate-sce/readme.md
+++ b/modules/simulate-sce/readme.md
@@ -4,4 +4,4 @@ This workflow is designed to simulate single cell data, primarily using the [spl
 
 Scripts are derived from the the `simulate-sce` module of the [OpenScPCA-analysis](https://github.com/AlexsLemonade/OpenScPCA-analysis) repository.
 
-Permalink to the version used: https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/0a3d96089991dea692a8485e3126ed6d69958028/analyses/simulate-sce
+Permalink to the version used: https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/0c105e1a482dc045478e88339633999ba9982f1c/analyses/simulate-sce

--- a/modules/simulate-sce/resources/usr/bin/simulate-sce.R
+++ b/modules/simulate-sce/resources/usr/bin/simulate-sce.R
@@ -178,9 +178,14 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
 
 
   # Perform simulation ---------------------------------------------------------
-  sim_params <- splatter::simpleEstimate(as.matrix(counts(sce_sim)))
+  # remove any all-zero droplets that might have slipped through
+  droplets <- colnames(sce)[which(colSums(counts(sce)) > 0)]
+  # use a large subset for estimating parameters, but not all
+  est_matrix <- counts(sce)[, sample(droplets, min(1000, ncol(sce)))]
+  sim_params <- splatter::simpleEstimate(as.matrix(est_matrix))
+  sim_params@nCells <- ncells
   # get spliced ratio
-  spliced_ratio <- sum(assay(sce_sim, "spliced")) / sum(counts(sce))
+  spliced_ratio <- sum(assay(sce, "spliced")) / sum(counts(sce))
   counts(sce_sim, withDimnames = FALSE) <- counts(
     splatter::simpleSimulate(sim_params, verbose = FALSE)
   )


### PR DESCRIPTION
closes #104

This PR ports the changes from https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/898 than handle droplets that might have all zero counts after rounding. 

I also updated the readme to point to the correct source commit. 