### PR TITLE
Add module for seurat conversion

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -15,4 +15,7 @@ params{
   // doublet-detection module
   doublet_detection_container = 'public.ecr.aws/openscpca/doublet-detection:v0.1.0'
 
+  // seurat-conversion module
+  seurat_conversion_container = 'public.ecr.aws/openscpca/seurat-conversion:latest'
+
 }

--- a/config/containers.config
+++ b/config/containers.config
@@ -16,6 +16,6 @@ params{
   doublet_detection_container = 'public.ecr.aws/openscpca/doublet-detection:v0.2.0'
 
   // seurat-conversion module
-  seurat_conversion_container = 'public.ecr.aws/openscpca/seurat-conversion:0.2.0'
+  seurat_conversion_container = 'public.ecr.aws/openscpca/seurat-conversion:v0.2.0'
 
 }

--- a/config/containers.config
+++ b/config/containers.config
@@ -10,12 +10,12 @@ params{
   scpcatools_anndata_container = "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.1"
 
   // simulate-sce module
-  simulate_sce_container = 'public.ecr.aws/openscpca/simulate-sce:v0.1.0'
+  simulate_sce_container = 'public.ecr.aws/openscpca/simulate-sce:v0.2.0'
 
   // doublet-detection module
-  doublet_detection_container = 'public.ecr.aws/openscpca/doublet-detection:v0.1.0'
+  doublet_detection_container = 'public.ecr.aws/openscpca/doublet-detection:v0.2.0'
 
   // seurat-conversion module
-  seurat_conversion_container = 'public.ecr.aws/openscpca/seurat-conversion:latest'
+  seurat_conversion_container = 'public.ecr.aws/openscpca/seurat-conversion:0.2.0'
 
 }

--- a/main.nf
+++ b/main.nf
@@ -5,6 +5,7 @@ include { example } from './modules/example'
 include { simulate_sce } from './modules/simulate-sce'
 include { merge_sce } from './modules/merge-sce'
 include { detect_doublets } from './modules/doublet-detection'
+include { seurat_conversion } from './modules/seurat-conversion'
 
 // **** Parameter checks ****
 param_error = false
@@ -53,4 +54,7 @@ workflow {
 
   // Run the doublet detection workflow
   detect_doublets(sample_ch)
+
+  // Run the seurat conversion workflow
+  seurat_conversion(sample_ch)
 }

--- a/modules/seurat-conversion/README.md
+++ b/modules/seurat-conversion/README.md
@@ -1,0 +1,7 @@
+This module converts SingleCellExperiment objects to Seurat format.
+
+Scripts are derived from the the `seurat-conversion` module of the [OpenScPCA-analysis](https://github.com/AlexsLemonade/OpenScPCA-analysis) repository.
+
+Links to specific original files used in this module:
+
+- `convert-to-seurat.R`:  <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/27d1947869f3698c3b20a4481670fb00ea984a20/analyses/seurat-conversion/scripts/convert-to-seurat.R>

--- a/modules/seurat-conversion/README.md
+++ b/modules/seurat-conversion/README.md
@@ -1,7 +1,9 @@
 This module converts SingleCellExperiment objects to Seurat format.
 
+Currently, only processed SCE files are converted.
+
 Scripts are derived from the the `seurat-conversion` module of the [OpenScPCA-analysis](https://github.com/AlexsLemonade/OpenScPCA-analysis) repository.
 
 Links to specific original files used in this module:
 
-- `convert-to-seurat.R`:  <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/27d1947869f3698c3b20a4481670fb00ea984a20/analyses/seurat-conversion/scripts/convert-to-seurat.R>
+- `convert-to-seurat.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/27d1947869f3698c3b20a4481670fb00ea984a20/analyses/seurat-conversion/scripts/convert-to-seurat.R>

--- a/modules/seurat-conversion/main.nf
+++ b/modules/seurat-conversion/main.nf
@@ -1,0 +1,58 @@
+#!/usr/bin/env nextflow
+
+// Workflow to convert SCE objects to Seurat objects
+
+process seurat_convert {
+  container params.seurat_conversion_container
+  tag "${sample_id}"
+  label 'mem_8'
+  publishDir "${params.results_bucket}/${params.release_prefix}/seurat/${project_id}/${sample_id}", mode: 'copy'
+  input:
+    tuple val(sample_id),
+          val(project_id),
+          path(library_files)
+  output:
+    tuple val(sample_id),
+          val(project_id),
+          path(output_files)
+  script:
+    output_files = library_files
+      .collect{
+        it.name.replaceAll(/(?i).rds$/, "_seurat.rds")
+      }
+    """
+    # convert all files in the working directory, output to the same directory
+    convert-to-seurat.R -i . -o .
+    """
+
+  stub:
+    output_files = library_files
+      .collect{
+        it.name.replaceAll(/(?i).rds$/, "_seurat.rds")
+      }
+    """
+    for file in ${library_files}; do
+      touch \$(basename \${file%.rds}_seurat.rds)
+    done
+    """
+}
+
+
+
+workflow seurat_conversion {
+  take:
+    sample_ch  // [sample_id, project_id, sample_path]
+  main:
+    // create [sample_id, project_id, [list of processed files]]
+    libraries_ch = sample_ch
+      .map{sample_id, project_id, sample_path ->
+        def library_files = Utils.getLibraryFiles(sample_path, format: "sce", process_level: "processed")
+        return [sample_id, project_id, library_files]
+      }
+
+    // detect doublets
+    seurat_convert(libraries_ch)
+
+  emit:
+    seurat_convert.out // [sample_id, project_id, [list of seurat format files]]
+}

--- a/modules/seurat-conversion/resources/usr/bin/convert-to-seurat.R
+++ b/modules/seurat-conversion/resources/usr/bin/convert-to-seurat.R
@@ -1,0 +1,86 @@
+#!/usr/bin/env Rscript
+
+# This script takes a directory containing ScPCA-formatted SingleCellExperiment
+# objects (filtered or processed only) as `.rds` files and converts each object
+# to a Seurat object. The Seurat object is then saved as an `rds` file in the
+# specified output directory.
+
+
+library(optparse)
+
+# set up arguments
+option_list <- list(
+  make_option(
+    opt_str = c("-i", "--input_dir"),
+    type = "character",
+    help = "Path where SCE rds files are located. Will search recursively for files ending in `_processed.rds` or  `_filtered.rds`.",
+  ),
+  make_option(
+    opt_str = c("-o", "--output_dir"),
+    type = "character",
+    help = "Path where Seurat rds files will be saved.",
+  ),
+  make_option(
+    opt_str = c("--use_ensembl"),
+    dest = "use_symbols",
+    type = "logical",
+    default = TRUE,
+    action = "store_false",
+    help = "Use Ensembl ids for Seurat object. Default is to use gene symbols."
+  ),
+  make_option(
+    opt_str = c("--dedup_method"),
+    type = "character",
+    default = "sum",
+    help = "Method to use for deduplication. Default is 'sum', with the alternative 'unique'."
+  )
+)
+
+opts <- parse_args(OptionParser(option_list = option_list))
+
+stopifnot(
+  "The input directory does not exist" = file.exists(opts$input_dir),
+  "--dedup_method must be one of 'sum' or 'unique'" = opts$dedup_method %in% c("sum", "unique")
+)
+
+# get input file list with relative paths
+sce_paths <- list.files(
+  opts$input_dir,
+  pattern = "_(processed|filtered).rds$",
+  recursive = TRUE
+)
+
+if (length(sce_paths) == 0) {
+  warning("No SCE files found in input directory: ", opts$input_dir)
+}
+
+# There are several warnings when the SCE package loads (even implicitly)
+# Let's suppress them
+suppressPackageStartupMessages({
+  suppressWarnings(
+    library(SingleCellExperiment)
+  )
+})
+
+# convert each file
+sce_paths |> purrr::walk(\(path){
+  message("Converting ", path, " to Seurat format")
+  sce_file <- file.path(opts$input_dir, path)
+
+  # generate output file name
+  seurat_file <- file.path(
+    opts$output_dir,
+    stringr::str_replace(path, ".rds$", "_seurat.rds")
+  )
+  # create output subdirectory if it doesn't exist
+  fs::dir_create(dirname(seurat_file))
+
+  # perform processing
+  sce <- readRDS(sce_file)
+  seurat_obj <- rOpenScPCA::sce_to_seurat(
+    sce,
+    use_symbols = opts$use_symbols,
+    dedup_method = opts$dedup_method
+  )
+  saveRDS(seurat_obj, seurat_file)
+})


### PR DESCRIPTION
closes #108

Here I am adding a module to convert SCE objects to Seurat format. This directly uses the R script from corresponding OpenScPCA-analysis module, and the associated docker container. 

At the moment, I am only converting the processed data objects; we could also do filtered if desired, but it might make sense to do that as a separate workflow, or to have separate emissions for the workflow? If we want to do both, I will consider options for that conversion, but I expect most usage to be the processed objects for now.

I am labeling this as a draft in part because I think we will need a release of OpenScPCA-analysis so that we can use a versioned Docker image; right now I am just using `latest`, but that is not what we will want for the final workflow. 

With this PR filed, I will run some tests on the AWS infrastructure, which I will report on in comments.