### PR TITLE
Update output prefix for seurat conversion

### DIFF
--- a/modules/seurat-conversion/main.nf
+++ b/modules/seurat-conversion/main.nf
@@ -6,7 +6,7 @@ process seurat_convert {
   container params.seurat_conversion_container
   tag "${sample_id}"
   label 'mem_8'
-  publishDir "${params.results_bucket}/${params.release_prefix}/seurat/${project_id}/${sample_id}", mode: 'copy'
+  publishDir "${params.results_bucket}/${params.release_prefix}/seurat-conversion/${project_id}/${sample_id}", mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),


### PR DESCRIPTION
I realized when writing up release notes that the seurat conversion workflow output directory does not match the associated module name, so I am fixing that here. 

I will follow up by moving the files on S3 directly, to avoid having to rerun the whole workflow. 