### PR TITLE
Add user bin directories to path in script

### DIFF
--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -22,6 +22,13 @@ RESUME=${RESUME:-false}
 date=$(date "+%Y-%m-%d")
 datetime=$(date "+%Y-%m-%dT%H%M")
 
+# Make sure environment includes local bin (where Nextflow is installed)
+if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]
+then
+    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
+fi
+export PATH
+
 # Get secrets from AWS Secrets Manager/1Password
 AWS_SECRETS=$(aws secretsmanager get-secret-value --secret-id openscpca_service_account_token | jq -r '.SecretString')
 # AWS secrets are a key-value store: retrieve individual values with jq


### PR DESCRIPTION
While we had previously had `nextflow` in  `/usr/local/bin` on the deploy box, this makes updating versions quite challenging. So we would like to move it to a user directory, but we need to make sure that is in the path when we run. So this adds user paths to `PATH` within the launch script, to ensure nextflow can be found and executed.