### PR TITLE
Update module containers to use v0.2.1 tag

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -10,13 +10,13 @@ params{
   scpcatools_anndata_container = "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.1"
 
   // simulate-sce module
-  simulate_sce_container = 'public.ecr.aws/openscpca/simulate-sce:v0.2.0'
+  simulate_sce_container = 'public.ecr.aws/openscpca/simulate-sce:v0.2.1'
 
   // doublet-detection module
-  doublet_detection_container = 'public.ecr.aws/openscpca/doublet-detection:v0.2.0'
+  doublet_detection_container = 'public.ecr.aws/openscpca/doublet-detection:v0.2.1'
 
   // seurat-conversion module
-  seurat_conversion_container = 'public.ecr.aws/openscpca/seurat-conversion:v0.2.0'
+  seurat_conversion_container = 'public.ecr.aws/openscpca/seurat-conversion:v0.2.1'
 
   // cell-type-consensus module
   consensus_cell_type_container = 'public.ecr.aws/openscpca/cell-type-consensus:latest'


### PR DESCRIPTION
Following the latest release of `OpenScPCA-analysis`, this updates the containers used in this workflow to use the `v0.2.1` tag. I didn't update the one for consensus cell typing since that is done in #118. 