### PR TITLE
Update link to consensus reference

### DIFF
--- a/config/module_params.config
+++ b/config/module_params.config
@@ -10,6 +10,6 @@ params{
   // cell type consensus
   cell_type_blueprint_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/blueprint-mapped-ontologies.tsv'
   cell_type_panglao_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv'
-  cell_type_consensus_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv'
+  cell_type_consensus_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/e4dc422dd8ddcdc89d031c289fbd123748db500c/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv'
 
 }

--- a/modules/cell-type-consensus/README.md
+++ b/modules/cell-type-consensus/README.md
@@ -10,4 +10,4 @@ This module also uses the following reference files found in the `OpenScPCA-anal
 
 - `blueprint-mapped-ontologies.tsv` : <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/e4ffb305a87a54133f398c4445ff92348fcb9d8a/analyses/cell-type-consensus/references/blueprint-mapped-ontologies.tsv>
 - `panglao-cell-type-ontologies.tsv`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/b870a082bc9acd3536c5f8d2d52550d8fe8a4239/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv>
-- `consensus-cell-type-reference.tsv`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/e4ffb305a87a54133f398c4445ff92348fcb9d8a/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv>
+- `consensus-cell-type-reference.tsv`: <https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/e4dc422dd8ddcdc89d031c289fbd123748db500c/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv>

--- a/modules/cell-type-consensus/README.md
+++ b/modules/cell-type-consensus/README.md
@@ -8,6 +8,6 @@ Links to specific original scripts used in this module:
 
 This module also uses the following reference files found in the `OpenScPCA-analysis` repository:
 
-- `blueprint-mapped-ontologies.tsv` : <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/e4ffb305a87a54133f398c4445ff92348fcb9d8a/analyses/cell-type-consensus/references/blueprint-mapped-ontologies.tsv>
-- `panglao-cell-type-ontologies.tsv`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/b870a082bc9acd3536c5f8d2d52550d8fe8a4239/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv>
-- `consensus-cell-type-reference.tsv`: <https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/e4dc422dd8ddcdc89d031c289fbd123748db500c/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv>
+- `blueprint-mapped-ontologies.tsv` : <https://github.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/blueprint-mapped-ontologies.tsv>
+- `panglao-cell-type-ontologies.tsv`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv>
+- `consensus-cell-type-reference.tsv`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/e4dc422dd8ddcdc89d031c289fbd123748db500c/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv>

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -83,7 +83,7 @@
         },
         "cell_type_consensus_ref_file": {
           "type": "string",
-          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv",
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/e4dc422dd8ddcdc89d031c289fbd123748db500c/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv",
           "pattern": "\\.tsv$",
           "format": "file-path",
           "mimetype": "text/tab-separated-values",


### PR DESCRIPTION
Closes #125 

Here I am updating the link to the consensus cell type reference since we made a change to it in https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/1037. I decided to just use the permalink with a hash rather than a tagged version of the file, since we are blocked by https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/1040 before we can create a new release of `OpenScPCA-analysis`. 

I want to be able to update this and then re-run for staging and production so that we ensure the results in the workflow bucket are correct. Are we okay with this approach? 