### PR TITLE
Save marker gene expression for cell-type-consensus module

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -19,5 +19,5 @@ params{
   seurat_conversion_container = 'public.ecr.aws/openscpca/seurat-conversion:v0.2.1'
 
   // cell-type-consensus module
-  consensus_cell_type_container = 'public.ecr.aws/openscpca/cell-type-consensus:v0.2.1'
+  consensus_cell_type_container = 'public.ecr.aws/openscpca/cell-type-consensus:latest'
 }

--- a/config/containers.config
+++ b/config/containers.config
@@ -10,14 +10,14 @@ params{
   scpcatools_anndata_container = "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.1"
 
   // simulate-sce module
-  simulate_sce_container = 'public.ecr.aws/openscpca/simulate-sce:v0.2.1'
+  simulate_sce_container = 'public.ecr.aws/openscpca/simulate-sce:v0.2.2'
 
   // doublet-detection module
-  doublet_detection_container = 'public.ecr.aws/openscpca/doublet-detection:v0.2.1'
+  doublet_detection_container = 'public.ecr.aws/openscpca/doublet-detection:v0.2.2'
 
   // seurat-conversion module
-  seurat_conversion_container = 'public.ecr.aws/openscpca/seurat-conversion:v0.2.1'
+  seurat_conversion_container = 'public.ecr.aws/openscpca/seurat-conversion:v0.2.2'
 
   // cell-type-consensus module
-  consensus_cell_type_container = 'public.ecr.aws/openscpca/cell-type-consensus:latest'
+  consensus_cell_type_container = 'public.ecr.aws/openscpca/cell-type-consensus:v0.2.2'
 }

--- a/config/module_params.config
+++ b/config/module_params.config
@@ -8,9 +8,9 @@ params{
 
 
   // cell type consensus
-  cell_type_blueprint_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/blueprint-mapped-ontologies.tsv'
-  cell_type_panglao_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv'
-  cell_type_consensus_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/e4dc422dd8ddcdc89d031c289fbd123748db500c/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv'
-  cell_type_consensus_marker_gene_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/872fd2b8256434221512b04fac7c98140704ede3/analyses/cell-type-consensus/references/validation-markers.tsv'
+  cell_type_blueprint_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/blueprint-mapped-ontologies.tsv'
+  cell_type_panglao_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv'
+  cell_type_consensus_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv'
+  cell_type_consensus_marker_gene_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/validation-markers.tsv'
 
 }

--- a/config/module_params.config
+++ b/config/module_params.config
@@ -11,5 +11,6 @@ params{
   cell_type_blueprint_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/blueprint-mapped-ontologies.tsv'
   cell_type_panglao_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv'
   cell_type_consensus_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/e4dc422dd8ddcdc89d031c289fbd123748db500c/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv'
+  cell_type_consensus_marker_gene_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/872fd2b8256434221512b04fac7c98140704ede3/analyses/cell-type-consensus/references/validation-markers.tsv'
 
 }

--- a/main.nf
+++ b/main.nf
@@ -52,13 +52,13 @@ workflow {
     .filter{ run_all || it[1] in project_ids }
 
   // Run the merge workflow
-  merge_sce(sample_ch)
+  //merge_sce(sample_ch)
 
   // Run the doublet detection workflow
-  detect_doublets(sample_ch)
+  //detect_doublets(sample_ch)
 
   // Run the seurat conversion workflow
-  seurat_conversion(sample_ch)
+  //seurat_conversion(sample_ch)
 
   // Run the consensus cell type workflow
   cell_type_consensus(sample_ch)

--- a/main.nf
+++ b/main.nf
@@ -52,13 +52,13 @@ workflow {
     .filter{ run_all || it[1] in project_ids }
 
   // Run the merge workflow
-  //merge_sce(sample_ch)
+  merge_sce(sample_ch)
 
   // Run the doublet detection workflow
-  //detect_doublets(sample_ch)
+  detect_doublets(sample_ch)
 
   // Run the seurat conversion workflow
-  //seurat_conversion(sample_ch)
+  seurat_conversion(sample_ch)
 
   // Run the consensus cell type workflow
   cell_type_consensus(sample_ch)

--- a/modules/cell-type-consensus/README.md
+++ b/modules/cell-type-consensus/README.md
@@ -11,3 +11,4 @@ This module also uses the following reference files found in the `OpenScPCA-anal
 - `blueprint-mapped-ontologies.tsv` : <https://github.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/blueprint-mapped-ontologies.tsv>
 - `panglao-cell-type-ontologies.tsv`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv>
 - `consensus-cell-type-reference.tsv`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/e4dc422dd8ddcdc89d031c289fbd123748db500c/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv>
+- `validation-markers.tsv`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/analyses/cell-type-consensus/references/validation-markers.tsv>

--- a/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
+++ b/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
@@ -13,6 +13,15 @@
 # consensus_annotation: human readable name associated with the consensus label
 # consensus_ontology: CL ontology term for the consensus cell type
 
+# An additional TSV file containing the expression for a set of marker genes is saved
+# the `logcounts` for all genes in `ensembl_gene_id` column of the `marker_gene_file` will be saved to the output file
+
+# output TSV columns
+# library_id
+# barcodes
+# ensembl_gene_id
+# gene_expression
+
 library(optparse)
 
 option_list <- list(
@@ -37,9 +46,21 @@ option_list <- list(
     help = "Path to file containing the reference for assigning consensus cell type labels"
   ),
   make_option(
-    opt_str = c("--output_file"),
+    opt_str = c("--marker_gene_file"),
     type = "character",
-    help = "Path to file where combined TSV file will be saved.
+    help = "Path to file containing a table of marker genes.
+     The logcounts for all genes in the `ensembl_gene_id` column that are expressed in the input SCE will be saved."
+  ),
+  make_option(
+    opt_str = c("--consensus_output_file"),
+    type = "character",
+    help = "Path to file where TSV file containing consensus cell types will be saved.
+      File name must end in either `.tsv` or `.tsv.gz` to save a compressed TSV file"
+  ),
+  make_option(
+    opt_str = c("--gene_exp_output_file"),
+    type = "character",
+    help = "Path to file where TSV file containing marker gene expression will be saved.
       File name must end in either `.tsv` or `.tsv.gz` to save a compressed TSV file"
   )
 )
@@ -55,13 +76,23 @@ stopifnot(
   "blueprint reference file does not exist" = file.exists(opt$blueprint_ref_file),
   "panglao reference file does not exist" = file.exists(opt$panglao_ref_file),
   "cell type consensus reference file does not exist" = file.exists(opt$consensus_ref_file),
-  "output file must end in `.tsv` or `.tsv.gz`" = stringr::str_ends(opt$output_file, "\\.tsv|\\.tsv\\.gz")
+  "marker gene file does not exist" = file.exists(opt$marker_gene_file),
+  "consensus output file must end in `.tsv` or `.tsv.gz`" = stringr::str_ends(opt$consensus_output_file, "\\.tsv(\\.gz)?"),
+  "gene expression output file must end in `.tsv` or `.tsv.gz`" = stringr::str_ends(opt$gene_exp_output_file, "\\.tsv(\\.gz)?")
 )
 
 # load SCE
 suppressPackageStartupMessages({
   library(SingleCellExperiment)
 })
+
+# read in file
+markers_df <- readr::read_tsv(opt$marker_gene_file)
+
+# check that ensembl gene id is present
+stopifnot(
+  "ensembl_gene_id column is missing from marker gene file" = "ensembl_gene_id" %in% colnames(markers_df)
+)
 
 # Extract colData --------------------------------------------------------------
 
@@ -147,7 +178,7 @@ consensus_ref_df <- readr::read_tsv(opt$consensus_ref_file) |>
 # grab blueprint ref
 blueprint_df <- readr::read_tsv(opt$blueprint_ref_file)
 
-# Create combined TSV ----------------------------------------------------------
+# Create consensus TSV ---------------------------------------------------------
 
 all_assignments_df <- celltype_df |>
   # add columns for panglao ontology and consensus
@@ -169,4 +200,52 @@ all_assignments_df <- celltype_df |>
   dplyr::mutate(consensus_annotation = dplyr::if_else(is.na(consensus_annotation) & (sample_type != "cell line"), "Unknown", consensus_annotation))
 
 # export file
-readr::write_tsv(all_assignments_df, opt$output_file)
+readr::write_tsv(all_assignments_df, opt$consensus_output_file)
+
+# Save gene expression file ----------------------------------------------------
+
+
+# list of all marker genes
+all_markers <- markers_df |>
+  dplyr::pull(ensembl_gene_id) |>
+  unique()
+
+# we only care about if that gene is expressed otherwise we won't waste memory and include it
+expressed_genes <- rowData(sce) |>
+  as.data.frame() |>
+  dplyr::filter(detected > 0) |>
+  dplyr::pull(gene_ids)
+
+# get markers that are expressed
+expressed_markers <- intersect(all_markers, expressed_genes)
+
+# if no markers are found, fill in columns with NA
+if (length(expressed_markers) == 0) {
+  (
+
+    gene_exp_df <- data.frame(
+      barcodes = rownames(sce),
+      library_id = library_id,
+      ensembl_gene_id = NA,
+      gene_expression = NA,
+      validation_group_annotation = NA,
+      validation_group_ontology = NA
+    )
+
+  )
+} else {
+  # get logcounts from sce for expressed genes
+  gene_exp_df <- scuttle::makePerCellDF(
+    sce,
+    features = expressed_markers,
+    assay.type = "logcounts",
+    use.coldata = "barcodes",
+    use.dimred = FALSE
+  ) |>
+    tidyr::pivot_longer(starts_with("ENSG"), names_to = "ensembl_gene_id", values_to = "logcounts") |>
+    # add library id column
+    dplyr::mutate(library_id = library_id, .before = 0)
+}
+
+# export the file
+readr::write_tsv(gene_exp_df, opt$gene_exp_output_file)

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -67,7 +67,7 @@
         },
         "cell_type_blueprint_ref_file": {
           "type": "string",
-          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/blueprint-mapped-ontologies.tsv",
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/blueprint-mapped-ontologies.tsv",
           "pattern": "\\.tsv$",
           "format": "file-path",
           "mimetype": "text/tab-separated-values",
@@ -75,7 +75,7 @@
         },
         "cell_type_panglao_ref_file": {
           "type": "string",
-          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.1/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv",
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv",
           "pattern": "\\.tsv$",
           "format": "file-path",
           "mimetype": "text/tab-separated-values",
@@ -83,7 +83,7 @@
         },
         "cell_type_consensus_ref_file": {
           "type": "string",
-          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/e4dc422dd8ddcdc89d031c289fbd123748db500c/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv",
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv",
           "pattern": "\\.tsv$",
           "format": "file-path",
           "mimetype": "text/tab-separated-values",
@@ -91,7 +91,7 @@
         },
         "cell_type_consensus_marker_gene_ref_file": {
           "type": "string",
-          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/872fd2b8256434221512b04fac7c98140704ede3/analyses/cell-type-consensus/references/validation-markers.tsv'",
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/validation-markers.tsv'",
           "pattern": "\\.tsv$",
           "format": "file-path",
           "mimetype": "text/tab-separated-values",
@@ -123,19 +123,19 @@
         },
         "simulate_sce_container": {
           "type": "string",
-          "default": "public.ecr.aws/openscpca/simulate-sce:v0.2.1"
+          "default": "public.ecr.aws/openscpca/simulate-sce:v0.2.2"
         },
         "doublet_detection_container": {
           "type": "string",
-          "default": "public.ecr.aws/openscpca/doublet-detection:v0.2.1"
+          "default": "public.ecr.aws/openscpca/doublet-detection:v0.2.2"
         },
         "seurat_conversion_container": {
           "type": "string",
-          "default": "public.ecr.aws/openscpca/seurat-conversion:v0.2.1"
+          "default": "public.ecr.aws/openscpca/seurat-conversion:v0.2.2"
         },
         "consensus_cell_type_container": {
           "type": "string",
-          "default": "public.ecr.aws/openscpca/cell-type-consensus:latest"
+          "default": "public.ecr.aws/openscpca/cell-type-consensus:v0.2.2"
         }
       }
     }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -91,7 +91,7 @@
         },
         "cell_type_consensus_marker_gene_ref_file": {
           "type": "string",
-          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/validation-markers.tsv'",
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/validation-markers.tsv",
           "pattern": "\\.tsv$",
           "format": "file-path",
           "mimetype": "text/tab-separated-values",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -88,6 +88,14 @@
           "format": "file-path",
           "mimetype": "text/tab-separated-values",
           "description": "Consensus cell types reference file"
+        },
+        "cell_type_consensus_marker_gene_ref_file": {
+          "type": "string",
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/872fd2b8256434221512b04fac7c98140704ede3/analyses/cell-type-consensus/references/validation-markers.tsv'",
+          "pattern": "\\.tsv$",
+          "format": "file-path",
+          "mimetype": "text/tab-separated-values",
+          "description": "Table of marker genes used to validate consensus cell types"
         }
       }
     },
@@ -127,7 +135,7 @@
         },
         "consensus_cell_type_container": {
           "type": "string",
-          "default": "public.ecr.aws/openscpca/cell-type-consensus:v0.2.1"
+          "default": "public.ecr.aws/openscpca/cell-type-consensus:latest"
         }
       }
     }


### PR DESCRIPTION
Closes #128 
Closes #125 

This PR modifies the `cell-type-consensus` module to also export a table of logcounts for all marker genes used for validating cell types (see https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/analyses/cell-type-consensus/references/validation-markers.tsv). I copied over the script from `OpenScPCA-analysis` to incorporate the new changes for saving gene expression. 

For the workflow itself, I modified it to have two output files, one for consensus and one for marker genes. And then I added a new parameter for the marker gene file. 

While I was here I updated the link for the consensus reference to use a tagged version again. I also had to update the consensus docker image since we are now using `scuttle`. I updated all the tags to v0.2.2 while I was at it. 
 
Once all the images for [`OpenScPCA-analysis` v0.2.2](https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/runs/13464897162) are finished building then I'll do a test run of the workflow. 