### PR TITLE
add typos rule for aucThr

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,5 +37,5 @@ repos:
       - id: style-files
       - id: parsable-R
 ci:
-  autofix_prs: false
+  autofix_prs: true
   autoupdate_schedule: quarterly

--- a/_typos.toml
+++ b/_typos.toml
@@ -7,5 +7,5 @@ kms = "kms"
 [type.R]
 extend-glob = ["*.[rR]"]
 
-[type.R.extend-words]
+[type.R.extend-identifiers]
 aucThr = "aucThr"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,11 +1,8 @@
-[type.tf]
-extend-glob = ["*.tf"]
-
 [type.tf.extend-words]
 kms = "kms"
 
-[type.R]
-extend-glob = ["*.[rR]"]
+[type.r]
+extend-glob = ["*.r"]
 
-[type.R.extend-identifiers]
+[type.r.extend-identifiers]
 aucThr = "aucThr"

--- a/_typos.toml
+++ b/_typos.toml
@@ -3,3 +3,9 @@ extend-glob = ["*.tf"]
 
 [type.tf.extend-words]
 kms = "kms"
+
+[type.R]
+extend-glob = ["*.[rR]"]
+
+[type.R.extend-words]
+aucThr = "aucThr"

--- a/modules/cell-type-ewings/resources/usr/bin/aucell.R
+++ b/modules/cell-type-ewings/resources/usr/bin/aucell.R
@@ -222,7 +222,7 @@ auc_thresholds <- AUCell::AUCell_exploreThresholds(
 ) |>
   # extract select auc threshold
   purrr::map_dbl(\(results){
-    results$aucThe$selected
+    results$aucThr$selected
   })
 
 # put into a data frame for easy joining with all auc values

--- a/modules/cell-type-ewings/resources/usr/bin/aucell.R
+++ b/modules/cell-type-ewings/resources/usr/bin/aucell.R
@@ -222,7 +222,7 @@ auc_thresholds <- AUCell::AUCell_exploreThresholds(
 ) |>
   # extract select auc threshold
   purrr::map_dbl(\(results){
-    results$aucThr$selected
+    results$aucThe$selected
   })
 
 # put into a data frame for easy joining with all auc values


### PR DESCRIPTION
Does what it says! I updated `_typos.toml` to add rules for R files, which in this case is set to preserve `aucThr` as a string.

I also turned back on autofixing.