### PR TITLE
Update data release and add changelog for v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ You may want to add temporary notes here for tracking as features are added, bef
 
 ## v0.1.4
 
-- Default release datae for ScPCA data is set to `2025-03-20`
+- Default release date for ScPCA data is set to `2025-03-20`
 - One new module:
   - `cell-type-ewings`: Assigns cell types to Ewing sarcoma samples in `SCPCP000015`
 - One module as been updated:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Add new release notes in reverse numerical order (newest first) below this comme
 You may want to add temporary notes here for tracking as features are added, before a new release is ready.
 -->
 
+## v0.1.4
+
+- Default release datae for ScPCA data is set to `2025-03-20`
+- One new module:
+  - `cell-type-ewings`: Assigns cell types to Ewing sarcoma samples in `SCPCP000015`
+- One module as been updated:
+  - `cell-type-consensus`:
+    - Now uses the consensus cell type reference from [`OpenScPCA-analysis:v0.2.2`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.2/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv)
+    - Exports gene expression for a set of marker genes in addition to assigned consensus cell types
+
 ## v0.1.3
 
 - Two new modules:

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,7 +40,7 @@ plugins {
 
 // global default parameters for workflows: output buckets are set to staging by default
 params {
-  release_prefix = "2024-11-25"
+  release_prefix = "2025-03-20"
   release_bucket = "s3://openscpca-data-release"
   results_bucket = "s3://openscpca-nf-workflow-results-staging"
   sim_bucket = "s3://openscpca-test-data-release-staging"

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,7 +4,7 @@ manifest {
   homePage = 'https://github.com/AlexsLemonade/openScPCA-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.1.3'
+  version = 'v0.1.4'
   nextflowVersion = '>=24.04.0'
   contributors = [
     [

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -20,7 +20,7 @@
         },
         "release_prefix": {
           "type": "string",
-          "default": "2024-11-25",
+          "default": "2025-03-20",
           "format": "directory-path",
           "description": "Prefix for the specific release used as input"
         },


### PR DESCRIPTION
Towards #135 and related to https://github.com/AlexsLemonade/OpenScPCA-admin/issues/334

Here I'm updating the date for the ScPCA data release to use and then prepping for the tagged release v0.1.4. This included updating the tag in the manifest and then adding a changelog entry. I don't plan on doing this release until next week when the data release is complete. 

Just a note that according to the template in https://github.com/AlexsLemonade/OpenScPCA-admin/issues/334, we will need to create a tag in this repo that is dated to match the data release date. Doing this will trigger the GHA of the full workflow. And then creating a versioned release will also do that, so I think that means running through the full workflow twice. Let me know if I should decouple these changes to account for that, or maybe we don't do a versioned release if we want to avoid running the workflow through twice. We could just change the header for the changelog entry to be the date? 