### PR TITLE
Rename auc_threshold column in AUCell output to avoid duplication

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -53,13 +53,13 @@ workflow {
     .filter{ run_all || it[1] in project_ids }
 
   // Run the merge workflow
-  merge_sce(sample_ch)
+  //merge_sce(sample_ch)
 
   // Run the doublet detection workflow
-  detect_doublets(sample_ch)
+  //detect_doublets(sample_ch)
 
   // Run the seurat conversion workflow
-  seurat_conversion(sample_ch)
+  //seurat_conversion(sample_ch)
 
   // Run the consensus cell type workflow
   cell_type_consensus(sample_ch)

--- a/main.nf
+++ b/main.nf
@@ -53,13 +53,13 @@ workflow {
     .filter{ run_all || it[1] in project_ids }
 
   // Run the merge workflow
-  //merge_sce(sample_ch)
+  merge_sce(sample_ch)
 
   // Run the doublet detection workflow
-  //detect_doublets(sample_ch)
+  detect_doublets(sample_ch)
 
   // Run the seurat conversion workflow
-  //seurat_conversion(sample_ch)
+  seurat_conversion(sample_ch)
 
   // Run the consensus cell type workflow
   cell_type_consensus(sample_ch)

--- a/modules/cell-type-ewings/resources/usr/bin/aucell.R
+++ b/modules/cell-type-ewings/resources/usr/bin/aucell.R
@@ -3,7 +3,7 @@
 # This script is used to run `AUCell` on a single SCE object for a set of marker gene sets
 # gene sets used are custom gene sets and a set of Ewing specific gene sets from MsigDB
 # the results are exported as a single TSV file with the following columns:
-# `gene_set`, `barcodes`, `auc`, and `auc_threshold`
+# `gene_set`, `barcodes`, `auc`, and `aucell_threshold`
 
 
 library(optparse)
@@ -196,7 +196,7 @@ if (any(overlap_pct <= 0.20)) {
     barcodes = colnames(sce),
     gene_set = NA,
     auc = NA,
-    auc_thresholds = NA
+    aucell_threshold = NA
   ) |>
     readr::write_tsv(opt$output_file)
 
@@ -215,7 +215,7 @@ auc_results <- AUCell::AUCell_run(
 # Get threshold ----------------------------------------------------------------
 
 # get auc threshold for each geneset
-auc_thresholds <- AUCell::AUCell_exploreThresholds(
+aucell_thresholds <- AUCell::AUCell_exploreThresholds(
   auc_results,
   assign = TRUE,
   plotHist = FALSE
@@ -227,8 +227,8 @@ auc_thresholds <- AUCell::AUCell_exploreThresholds(
 
 # put into a data frame for easy joining with all auc values
 threshold_df <- data.frame(
-  gene_set = names(auc_thresholds),
-  auc_threshold = auc_thresholds
+  gene_set = names(aucell_thresholds),
+  aucell_threshold = aucell_thresholds
 )
 
 # Combine and export results ---------------------------------------------------


### PR DESCRIPTION
It looks like we had an error when assigning tumor cell states in the `cell-type-ewings` module, where instead of using the `auc_threhsold` defined in [`auc-thresholds.tsv`](https://github.com/AlexsLemonade/OpenScPCA-nf/blob/main/modules/cell-type-ewings/resources/auc-thresholds.tsv) to classify cells, we were accidentally using the pre-calculated AUC threshold determined by `AUCell`. This was because the output of `AUCell` included a data frame with an `auc_threshold` column that provides the automatically determined AUC value that `AUCell` identified. We then read this into a script that assigns cell states, and use a pre-set `auc_threshold` to determine if the cell is classified as tumor cell. But because the column and the variable were both named with `auc_threshold` (see https://github.com/AlexsLemonade/OpenScPCA-nf/blob/a97e88c411cabb1b41e1fce6a7735311fb435051/modules/cell-type-ewings/resources/usr/bin/assign-celltypes.R#L79), it was using the value calculated by `AUCell`. 

This is why the one library, SCPCL000822, looked correct since that library has a nice bimodal distribution and tumor cells are easily classified using the pre-calculated AUC in AUCell. But this doesn't hold true for the other libraries and why we were getting very few tumor cells. 

To fix this, I changed the output from running `AUCell` to have the column be `aucell_threshold` rather than `auc_threshold`. This means no modification to the assignment code to deal with the double variable naming and hopefully makes it more clear that the column contains the threshold determined by `AUCell`. 