### PR TITLE
Update release_prefix to 2025-06-30

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -40,7 +40,7 @@ plugins {
 
 // global default parameters for workflows: output buckets are set to staging by default
 params {
-  release_prefix = "2025-03-20"
+  release_prefix = "2025-06-30"
   release_bucket = "s3://openscpca-data-release"
   results_bucket = "s3://openscpca-nf-workflow-results-staging"
   sim_bucket = "s3://openscpca-test-data-release-staging"


### PR DESCRIPTION
Part of https://github.com/AlexsLemonade/OpenScPCA-admin/issues/366
Does what it says!

Noting I confirmed that SCEs (ok, I confirmed 1, but should suffice) indeed contain consensus cell type annotations in `s3://openscpca-data-release/2025-06-30/`, currently in our `workloads` account.

While I'm here, I wanted to ask whether we want to comment out the consensus cell type workflow at this time before I tag?
- Benefit: save compute when running the workflow since it's redundant to calculate all this again
- Drawback (which actually is a massive drawback I now realize...): it will break code that is downloading results from the consensus module from the `current` release

I do believe I have answered my question and we should _not_ comment it out, because of code breaking. But this could be something to generally think about in the future if a lot of module results end up making it onto the portal.
