### PR TITLE
Add consensus colnames to retain

### DIFF
--- a/modules/merge-sce/resources/usr/bin/merge_sces.R
+++ b/modules/merge-sce/resources/usr/bin/merge_sces.R
@@ -202,6 +202,8 @@ possible_columns <- c(
   "singler_celltype_ontology",
   "cellassign_celltype_annotation",
   "cellassign_max_prediction",
+  "consensus_celltype_annotation",
+  "consensus_celltype_ontology",
   # ADT statistics
   "adt_scpca_filter",
   "altexps_adt_sum",


### PR DESCRIPTION
Closes #143 

This PR preps to re-run the `merge-sce` module to get updated objects with consensus cell types into the bucket next (#147). I added the consensus columns to the vector of columns to keep, so this should be it!