### PR TITLE
Updates towards new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You may want to add temporary notes here for tracking as features are added, bef
 ## v0.1.5
 
 - Default release date for ScPCA data is set to `2025-06-30`
+- Update scpcaTools images to v0.4.3 versions
 - One new module:
   - `infercnv-gene-order-file`: Produce gene order files that can be used as input to `inferCNV`
 - Two modules have been updated:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,26 @@ Add new release notes in reverse numerical order (newest first) below this comme
 You may want to add temporary notes here for tracking as features are added, before a new release is ready.
 -->
 
+## v0.1.5
+
+- Default release date for ScPCA data is set to `2025-06-30`
+- One new module:
+  - `infercnv-gene-order-file`: Produce gene order files that can be used as input to `inferCNV`
+- Two modules have been updated:
+  - `merge-sce`:
+    - Two bugs were fixed:
+      - The `cell_id` column in the merged object `colData` slot is now correctly formatted as `{library id}-{barcode}`
+      - Merged object `colData` slots now include consensus cell type annotations in columns `consensus_celltype_annotation` and `consensus_celltype_ontology`
+  - `cell-type-ewings`:
+    - A bug causing some cells to be incorrectly classified was fixed
+
+
 ## v0.1.4
 
 - Default release date for ScPCA data is set to `2025-03-20`
 - One new module:
   - `cell-type-ewings`: Assigns cell types to Ewing sarcoma samples in `SCPCP000015`
-- One module as been updated:
+- One module has been updated:
   - `cell-type-consensus`:
     - Now uses the consensus cell type reference from [`OpenScPCA-analysis:v0.2.2`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.2/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv)
     - Exports gene expression for a set of marker genes in addition to assigned consensus cell types

--- a/config/containers.config
+++ b/config/containers.config
@@ -4,10 +4,10 @@ params{
   // example module
   python_container = 'python:3.11'
 
-  // scpcaTools containers (used by `merge-sce` module)
-  scpcatools_slim_container = 'ghcr.io/alexslemonade/scpcatools-slim:v0.4.1'
-  scpcatools_reports_container = 'ghcr.io/alexslemonade/scpcatools-reports:v0.4.1'
-  scpcatools_anndata_container = "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.1"
+  // scpcaTools containers: used by `merge-sce` and `infercnv-gene-order` modules
+  scpcatools_slim_container = 'ghcr.io/alexslemonade/scpcatools-slim:v0.4.3'
+  scpcatools_reports_container = 'ghcr.io/alexslemonade/scpcatools-reports:v0.4.3'
+  scpcatools_anndata_container = "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.3"
 
   // simulate-sce module
   simulate_sce_container = 'public.ecr.aws/openscpca/simulate-sce:v0.2.2'

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,7 +4,7 @@ manifest {
   homePage = 'https://github.com/AlexsLemonade/openScPCA-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.1.4'
+  version = 'v0.1.5'
   nextflowVersion = '>=24.04.0'
   contributors = [
     [


### PR DESCRIPTION
Closes #146 
Towards #145 

This PR takes care of the following pre-release items:

- For #146, bump the `scpcaTools` version
- For #145 items:
  - I updated the `CHANGELOG.md` with an entry for this release. Based on all the PRs that have gone in since the last release I think this is everything - did I miss anything?
  - I updated _this_ workflow version in `nextflow.config`

After this, I should be set to run the workflow.