### PR TITLE
Update module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You may want to add temporary notes here for tracking as features are added, bef
 - Default release date for ScPCA data is set to `2025-06-30`
 - Update scpcaTools images to v0.4.3 versions
 - One new module:
-  - `infercnv-gene-order-file`: Produce gene order files that can be used as input to `inferCNV`
+  - `infercnv-gene-order`: Produce gene order files that can be used as input to `inferCNV`
 - Two modules have been updated:
   - `merge-sce`:
     - Two bugs were fixed:


### PR DESCRIPTION
For making the release, I caught this wrong name in the CHANGELOG. The new module was called `infercnv-gene-order-file` at first but got changed to `infercnv-gene-order` along the way, but this didn't make it into the CHANGELOG. Done now!