### PR TITLE
Keep the doublet columns in merged objects

### DIFF
--- a/modules/merge-sce/resources/usr/bin/merge_sces.R
+++ b/modules/merge-sce/resources/usr/bin/merge_sces.R
@@ -196,6 +196,8 @@ possible_columns <- c(
   "prob_compromised",
   "scpca_filter",
   "additional_modalities",
+  "scDblFinder_class",
+  "scDblFinder_score",
   # cell type names
   "submitter_celltype_annotation",
   "singler_celltype_annotation",


### PR DESCRIPTION
Closes #158 
This PR is the "duplicate" of https://github.com/AlexsLemonade/scpca-nf/pull/941. I'm adding the new columns to the vector of columns to retain.