### PR TITLE
Initiate NB module and convert NBAtlas

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -24,4 +24,9 @@ params{
   // cell-type-ewings module
   cell_type_ewing_container = 'public.ecr.aws/openscpca/cell-type-ewings:v0.2.2'
 
+  // cell-type-neuroblastoma-04 module
+  // TODO: Update container tag once available
+  cell_type_nb_04_container = 'public.ecr.aws/openscpca/cell-type-neuroblastoma-04:latest'
+
+
 }

--- a/config/module_params.config
+++ b/config/module_params.config
@@ -22,11 +22,11 @@ params{
   cell_type_ewings_auc_thresholds_file = "${projectDir}/modules/cell-type-ewings/resources/auc-thresholds.tsv"
 
   // cell type neuroblastoma
-  cell_type_nb_scanvi_pp_threshold = 0.75 // posterior probability threshold for assigning cell types using scANVI
-  cell_type_nb_nbatlas_url = 'https://data.mendeley.com/public-files/datasets/yhcf6787yp/files/f5969395-5f6e-4c5d-a61a-5894773d0fee/file_downloaded' // direct link to download `seuratObj_NBAtlas_share_v20241203.rds` from https://doi.org/10.17632/yhcf6787yp.3
+  cell_type_nb_04_scanvi_pp_threshold = 0.75 // posterior probability threshold for assigning cell types using scANVI
+  cell_type_nb_04_nbatlas_url = 'https://data.mendeley.com/public-files/datasets/yhcf6787yp/files/f5969395-5f6e-4c5d-a61a-5894773d0fee/file_downloaded' // direct link to download `seuratObj_NBAtlas_share_v20241203.rds` from https://doi.org/10.17632/yhcf6787yp.3
   // TODO: Replace these files with tagged links once we have a new OpenScPCA-analysis tag
-  cell_type_nb_validation_group_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-consensus/references/consensus-validation-groups.tsv'
-  cell_type_nb_label_map_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-label-map.tsv'
-  cell_type_nb_ontology_map_fie = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-ontology-ids.tsv'
+  cell_type_nb_04_validation_group_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-consensus/references/consensus-validation-groups.tsv'
+  cell_type_nb_04_label_map_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-label-map.tsv'
+  cell_type_nb_04_ontology_map_fie = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-ontology-ids.tsv'
 
 }

--- a/config/module_params.config
+++ b/config/module_params.config
@@ -21,4 +21,12 @@ params{
   cell_type_ewings_marker_gene_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-ewings/references/tumor-cell-state-markers.tsv'
   cell_type_ewings_auc_thresholds_file = "${projectDir}/modules/cell-type-ewings/resources/auc-thresholds.tsv"
 
+  // cell type neuroblastoma
+  cell_type_nb_scanvi_pp_threshold = 0.75 // posterior probability threshold for assigning cell types using scANVI
+  cell_type_nb_nbatlas_url = 'https://data.mendeley.com/public-files/datasets/yhcf6787yp/files/f5969395-5f6e-4c5d-a61a-5894773d0fee/file_downloaded' // direct link to download `seuratObj_NBAtlas_share_v20241203.rds` from https://doi.org/10.17632/yhcf6787yp.3
+  // TODO: Replace these files with tagged links once we have a new OpenScPCA-analysis tag
+  cell_type_nb_validation_group_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-consensus/references/consensus-validation-groups.tsv'
+  cell_type_nb_label_map_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-label-map.tsv'
+  cell_type_nb_ontology_map_fie = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-ontology-ids.tsv'
+
 }

--- a/main.nf
+++ b/main.nf
@@ -8,6 +8,7 @@ include { detect_doublets } from './modules/doublet-detection'
 include { seurat_conversion } from './modules/seurat-conversion'
 include { cell_type_consensus } from './modules/cell-type-consensus'
 include { cell_type_ewings } from './modules/cell-type-ewings'
+include { cell_type_neuroblastoma_04 } from './modules/cell-type-neuroblastoma-04'
 include { infercnv_gene_order } from './modules/infercnv-gene-order'
 
 // **** Parameter checks ****
@@ -71,4 +72,8 @@ workflow {
 
   // Run the infercnv gene order file workflow
   infercnv_gene_order()
+
+  // Run the cell type neuroblastoma 04 workflow
+  // only runs on SCPCP000004
+  cell_type_neuroblastoma_04(sample_ch.filter{ it[1] == "SCPCP000004" })
 }

--- a/modules/cell-type-neuroblastoma-04/README.md
+++ b/modules/cell-type-neuroblastoma-04/README.md
@@ -1,0 +1,3 @@
+This module assigns cell types to all Neuroblastoma samples in `SCPCP000004`.
+
+Scripts are derived from the the `cell-type-neuroblastoma-04` module of the [OpenScPCA-analysis](https://github.com/AlexsLemonade/OpenScPCA-analysis) repository.

--- a/modules/cell-type-neuroblastoma-04/README.md
+++ b/modules/cell-type-neuroblastoma-04/README.md
@@ -1,3 +1,7 @@
 This module assigns cell types to all Neuroblastoma samples in `SCPCP000004`.
 
 Scripts are derived from the the `cell-type-neuroblastoma-04` module of the [OpenScPCA-analysis](https://github.com/AlexsLemonade/OpenScPCA-analysis) repository.
+
+Links to specific original scripts used in this module:
+
+* `00-convert-nbatlas.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/ad3b3c6ac6bcb7154058e4f725250dc56523caa8/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R>

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -1,0 +1,17 @@
+#!/usr/bin/env nextflow
+
+// Workflow to assign neuroblastoma (SCPCP000004) cell type labels
+
+
+workflow cell_type_neuroblastoma_04 {
+  take:
+    sample_ch  // [sample_id, project_id, sample_path]
+  main:
+    // create [sample_id, project_id, [list of processed files]]
+    libraries_ch = sample_ch
+      .map{sample_id, project_id, sample_path ->
+        def library_files = Utils.getLibraryFiles(sample_path, format: "sce", process_level: "processed")
+        return [sample_id, project_id, library_files]
+      }
+
+}

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -3,6 +3,39 @@
 // Workflow to assign neuroblastoma (SCPCP000004) cell type labels
 
 
+process convert_nbatlas {
+  container params.cell_type_nb_04_container
+  label 'mem_8'
+  input:
+    path nbatlas_seurat_file
+  output:
+    path nbatlas_sce_file
+    path nbatlas_anndata_file
+    path nbatlas_hvg_file
+  script:
+    nbatlas_sce_file = "nbatlas_sce.rds"
+    nbatlas_anndata_file = "nbatlas_anndata.h5ad"
+    nbatlas_hvg_file = "nbatlas_hvg.txt.gz"
+    """
+    convert-nbatlas.R \
+      --nbatlas_file ${nbatlas_seurat_file} \
+      --sce_file ${nbatlas_sce_file} \
+      --anndata_file ${nbatlas_anndata_file} \
+      --nbatlas_hvg_file ${nbatlas_hvg_file}
+    """
+  stub:
+    nbatlas_sce_file = "nbatlas_sce.rds"
+    nbatlas_anndata_file = "nbatlas_anndata.rds"
+    nbatlas_hvg_file = "nbatlas_hvg.txt.gz"
+    """
+    touch ${nbatlas_sce_file}
+    touch ${nbatlas_anndata_file}
+    touch ${nbatlas_hvg_file}
+    """
+}
+
+
+
 workflow cell_type_neuroblastoma_04 {
   take:
     sample_ch  // [sample_id, project_id, sample_path]
@@ -13,5 +46,9 @@ workflow cell_type_neuroblastoma_04 {
         def library_files = Utils.getLibraryFiles(sample_path, format: "sce", process_level: "processed")
         return [sample_id, project_id, library_files]
       }
+
+    // convert NBAtlas to SCE and AnnData objects
+    // returns [nbatlas_sce_file, nbatlas_anndata_file, nbatlas_hvg_file]
+    convert_nbatlas(file(params.cell_type_nb_04_nbatlas_url))
 
 }

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -6,6 +6,8 @@
 process convert_nbatlas {
   container params.cell_type_nb_04_container
   label 'mem_8'
+  // TODO: Remove publishDir after initial PR
+  publishDir "${params.results_bucket}/${params.release_prefix}/cell-type-neuroblastoma-04"
   input:
     path nbatlas_seurat_file
   output:

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/convert-nbatlas.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/convert-nbatlas.R
@@ -1,0 +1,111 @@
+#!/usr/bin/env Rscript
+#
+# This script exports an SCE and AnnData version of a given NBAtlas Seurat object
+# The SCE object retains the raw counts, normalized counts, and cell metadata
+# The AnnData object retains only the raw counts for the top 2000 high-variance genes, and cell metadata
+#  This allows for a smaller object export and lower memory usage during SCVI/SCANVI training
+# In addition, a text file with the top 2000 high-variance genes is exported
+#
+# During processing, one piece of metadata in the object is further updated:
+# The `Platform` value for the Costa2022 Study should be `10x_v3.1` and not `10x_v3`
+# See this issue discussion for context:
+# https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/1231#discussion_r2226070913
+#
+# This script was adapted from:
+# https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/ad3b3c6ac6bcb7154058e4f725250dc56523caa8/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R
+
+library(optparse)
+
+option_list <- list(
+  make_option(
+    opt_str = c("--nbatlas_file"),
+    type = "character",
+    default = "",
+    help = "Path to Seurat version of an NBAtlas object"
+  ),
+  make_option(
+    opt_str = c("--sce_file"),
+    type = "character",
+    help = "Path to output RDS file to hold an SCE version of the NBAtlas object."
+  ),
+  make_option(
+    opt_str = c("--anndata_file"),
+    type = "character",
+    help = "Path to output H5AD file to hold an AnnData version of the NBAtlas object."
+  ),
+  make_option(
+    opt_str = c("--nbatlas_hvg_file"),
+    type = "character",
+    help = "Path to output text file to save top 2000 HVGs of the NBAtlas object."
+  )
+)
+
+# Parse options and check arguments
+opts <- parse_args(OptionParser(option_list = option_list))
+
+stopifnot("nbatlas_file does not exist" = file.exists(opts$nbatlas_file))
+
+# load the bigger libraries after passing checks
+suppressPackageStartupMessages({
+  library(Seurat)
+  library(SingleCellExperiment)
+  library(zellkonverter)
+})
+
+# read input file and convert to SCE
+nbatlas_seurat <- readRDS(opts$nbatlas_file)
+nbatlas_sce <- as.SingleCellExperiment(nbatlas_seurat)
+
+# remove Seurat file to save space
+rm(nbatlas_seurat)
+gc()
+
+# Update SCE innards:
+# - remove reducedDim for space
+# - add `cell_id` columns to colData
+# - update Costa2022 Platform to 10X_v3.1
+
+reducedDims(nbatlas_sce) <- NULL
+colData(nbatlas_sce) <- colData(nbatlas_sce) |>
+  as.data.frame() |>
+  dplyr::mutate(
+    cell_id = rownames(colData(nbatlas_sce)),
+    Platform = ifelse(
+      Study == "Costa2022",
+      "10X_v3.1",
+      Platform
+    )
+  ) |>
+  DataFrame(row.names = rownames(colData(nbatlas_sce)))
+
+# export SCE version of NBAtlas object
+readr::write_rds(
+  nbatlas_sce,
+  opts$sce_file,
+  compress = "gz"
+)
+
+
+# Perform some additional processing before AnnData export:
+# - subset to top 2000 HVGs (batch-aware); these will also be exported
+# - remove logcounts
+
+gene_var <- scran::modelGeneVar(
+  nbatlas_sce,
+  block = nbatlas_sce$Sample
+)
+hv_genes <- scran::getTopHVGs(gene_var, n = 2000)
+
+nbatlas_sce <- nbatlas_sce[hv_genes, ]
+logcounts(nbatlas_sce) <- NULL
+
+# export the AnnData object
+zellkonverter::writeH5AD(
+  nbatlas_sce,
+  opts$anndata_file,
+  X_name = "counts",
+  compression = "gzip"
+)
+
+# export text file with the HVGs
+readr::write_lines(hv_genes, opts$nbatlas_hvg_file)

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/convert-nbatlas.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/convert-nbatlas.R
@@ -43,7 +43,12 @@ option_list <- list(
 # Parse options and check arguments
 opts <- parse_args(OptionParser(option_list = option_list))
 
-stopifnot("nbatlas_file does not exist" = file.exists(opts$nbatlas_file))
+stopifnot(
+  "nbatlas_file does not exist" = file.exists(opts$nbatlas_file),
+  "sce_file was not provided" = !is.null(opts$sce_file),
+  "anndata_file was not provided" = !is.null(opts$anndata_file),
+  "nbatlas_hvg_file was not provided" = !is.null(opts$nbatlas_hvg_file)
+)
 
 # load the bigger libraries after passing checks
 suppressPackageStartupMessages({

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/convert-nbatlas.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/convert-nbatlas.R
@@ -54,7 +54,10 @@ suppressPackageStartupMessages({
 
 # read input file and convert to SCE
 nbatlas_seurat <- readRDS(opts$nbatlas_file)
-nbatlas_sce <- as.SingleCellExperiment(nbatlas_seurat)
+# seurat gives an expected warning here
+suppressWarnings({
+  nbatlas_sce <- as.SingleCellExperiment(nbatlas_seurat)
+})
 
 # remove Seurat file to save space
 rm(nbatlas_seurat)

--- a/nextflow.config
+++ b/nextflow.config
@@ -76,6 +76,8 @@ profiles {
       results_bucket = "test/results"
       sim_bucket = "test/simulated"
       project = "SCPCP000012"
+      // Override this module-specific parameter if testing to use the subsetted NBAtlas instead of the full
+      cell_type_nb_04_nbatlas_url = 'https://data.mendeley.com/public-files/datasets/yhcf6787yp/files/0a569381-3a0c-4eec-863a-e20544b686ed/file_downloaded' // direct link to download `seuratObj_NBAtlas_share_v20240130.rds` from https://doi.org/10.17632/yhcf6787yp.3
     }
     process {
       executor = 'local'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -227,10 +227,10 @@
       "$ref": "#/$defs/input_and_output_locations"
     },
     {
-      "$ref": "#/$defs/containers"
+      "$ref": "#/$defs/module_specific_parameters"
     },
     {
-      "$ref": "#/$defs/module_specific_parameters"
+      "$ref": "#/$defs/containers"
     }
   ],
   "properties": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -45,6 +45,58 @@
         }
       }
     },
+    "containers": {
+      "title": "Containers",
+      "type": "object",
+      "description": "Locations for Docker images used by workflow processes",
+      "default": "",
+      "properties": {
+        "python_container": {
+          "type": "string",
+          "default": "python:3.11"
+        },
+        "scpcatools_slim_container": {
+          "type": "string",
+          "default": "ghcr.io/alexslemonade/scpcatools-slim:v0.4.3"
+        },
+        "scpcatools_reports_container": {
+          "type": "string",
+          "default": "ghcr.io/alexslemonade/scpcatools-reports:v0.4.3"
+        },
+        "scpcatools_anndata_container": {
+          "type": "string",
+          "default": "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.3"
+        },
+        "simulate_sce_container": {
+          "type": "string",
+          "default": "public.ecr.aws/openscpca/simulate-sce:v0.2.2"
+        },
+        "doublet_detection_container": {
+          "type": "string",
+          "default": "public.ecr.aws/openscpca/doublet-detection:v0.2.2",
+          "description": "Docker container for the doublet-detection module to run in"
+        },
+        "seurat_conversion_container": {
+          "type": "string",
+          "default": "public.ecr.aws/openscpca/seurat-conversion:v0.2.2",
+          "description": "Docker container for the seurat-conversion module to run in"
+        },
+        "consensus_cell_type_container": {
+          "type": "string",
+          "default": "public.ecr.aws/openscpca/cell-type-consensus:v0.2.2",
+          "description": "Docker container for the cell-type-consensus module to run in"
+        },
+        "cell_type_ewing_container": {
+          "type": "string",
+          "default": "public.ecr.aws/openscpca/cell-type-ewings:v0.2.2",
+          "description": "Docker container for the cell-type-ewings module to run in"
+        },
+        "cell_type_nb_04_container": {
+          "type": "string",
+          "default": "public.ecr.aws/openscpca/cell-type-neuroblastoma-04:latest"
+        }
+      }
+    },
     "module_specific_parameters": {
       "title": "Module-specific parameters",
       "type": "object",
@@ -141,50 +193,31 @@
           "format": "file-path",
           "mimetype": "text/tab-separated-values",
           "description": "Table with AUC thresholds to use for each gene set to define cell states"
-        }
-      }
-    },
-    "containers": {
-      "title": "Containers",
-      "type": "object",
-      "description": "Locations for Docker images used by workflow processes",
-      "default": "",
-      "properties": {
-        "python_container": {
-          "type": "string",
-          "default": "python:3.11"
         },
-        "scpcatools_slim_container": {
-          "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools-slim:v0.4.1"
+        "cell_type_nb_04_scanvi_pp_threshold": {
+          "type": "number",
+          "default": 0.75,
+          "description": "Posterior probability threshold for annotating cells with scANVI/scArches"
         },
-        "scpcatools_reports_container": {
+        "cell_type_nb_04_label_map_file": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools-reports:v0.4.1"
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-label-map.tsv",
+          "description": "Path or URL to TSV mapping NBAtlas labels across levels of organization"
         },
-        "scpcatools_anndata_container": {
+        "cell_type_nb_04_validation_group_file": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.1"
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-consensus/references/consensus-validation-groups.tsv",
+          "description": "Path or URL to TSV mapping consensus cell types to broad validation groups"
         },
-        "simulate_sce_container": {
+        "cell_type_nb_04_ontology_map_fie": {
           "type": "string",
-          "default": "public.ecr.aws/openscpca/simulate-sce:v0.2.2"
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-ontology-ids.tsv",
+          "description": "Path or URL to TSV mapping NBAtlas labels to ontology ids"
         },
-        "doublet_detection_container": {
+        "cell_type_nb_04_nbatlas_url": {
           "type": "string",
-          "default": "public.ecr.aws/openscpca/doublet-detection:v0.2.2"
-        },
-        "seurat_conversion_container": {
-          "type": "string",
-          "default": "public.ecr.aws/openscpca/seurat-conversion:v0.2.2"
-        },
-        "consensus_cell_type_container": {
-          "type": "string",
-          "default": "public.ecr.aws/openscpca/cell-type-consensus:v0.2.2"
-        },
-        "cell_type_ewing_container": {
-          "type": "string",
-          "default": "public.ecr.aws/openscpca/cell-type-ewings:v0.2.2"
+          "default": "https://data.mendeley.com/public-files/datasets/yhcf6787yp/files/f5969395-5f6e-4c5d-a61a-5894773d0fee/file_downloaded",
+          "description": "Path or URL to the released NBAtlas object"
         }
       }
     }
@@ -194,10 +227,10 @@
       "$ref": "#/$defs/input_and_output_locations"
     },
     {
-      "$ref": "#/$defs/module_specific_parameters"
+      "$ref": "#/$defs/containers"
     },
     {
-      "$ref": "#/$defs/containers"
+      "$ref": "#/$defs/module_specific_parameters"
     }
   ],
   "properties": {


### PR DESCRIPTION
Closes #163 
Closes #164 

This PR starts the new module which I have aptly named `cell-type-neuroblastoma-04`. It includes:

- Module-specific parameters (some of which have TODOs related to tagging)
  - Note that I overrode the NBAtlas link in the testing profile to run with the subsetted version instead, for time. This will require me to use a testing flag though in other circumstances which I'm not sure how I feel about? The full atlas object just takes a while to download at 2.5 gb (could be worse of course, it's not scimilarity!). I'm really on the fence about bringing in the test version at all, what do you think?
- Added parameters to the schema json; some of the container versions needed to be updated here too, so I went ahead and did that and added some descriptions while I was at al
- Started of the new module
  -  `main.nf` with a process to convert the atlas, and the associated script is there too. The script exports three files for later use: the SCE atlas version, the AnnData atlas version, the list of HVGs for prepping objects for scANVI. 