### PR TITLE
Module for exporting openscpca annotations

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -77,7 +77,8 @@ workflow {
   cell_type_neuroblastoma_04(sample_ch.filter{ it[1] == "SCPCP000004" })
 
   // format and export json files with openscpca annotations
-  // input expected to be sample id, project id, tsv files, annotation column, ontology column, module name
+  // input expected to be sample id, project id, tsv files, annotation meta
+  // annotation meta should be [annotation column, ontology column, module name]
   // mix outputs from all cell type modules first
   export_ch = cell_type_ewings.out.celltypes
   export_annotations(export_ch)

--- a/main.nf
+++ b/main.nf
@@ -78,7 +78,7 @@ workflow {
 
   // format and export json files with openscpca annotations
   // input expected to be sample id, project id, tsv files, annotation meta
-  // annotation meta should be [annotation column, ontology column, module name]
+  // annotation meta should be [module name, annotation column, ontology column]
   // mix outputs from all cell type modules first
   export_ch = cell_type_ewings.out.celltypes
   export_annotations(export_ch)

--- a/main.nf
+++ b/main.nf
@@ -56,13 +56,13 @@ workflow {
     .filter{ run_all || it[1] in project_ids }
 
   // Run the merge workflow
-  //merge_sce(sample_ch)
+  merge_sce(sample_ch)
 
   // Run the doublet detection workflow
-  //detect_doublets(sample_ch)
+  detect_doublets(sample_ch)
 
   // Run the seurat conversion workflow
-  //seurat_conversion(sample_ch)
+  seurat_conversion(sample_ch)
 
   // Run the consensus cell type workflow
   cell_type_consensus(sample_ch)

--- a/main.nf
+++ b/main.nf
@@ -55,13 +55,13 @@ workflow {
     .filter{ run_all || it[1] in project_ids }
 
   // Run the merge workflow
-  merge_sce(sample_ch)
+  //merge_sce(sample_ch)
 
   // Run the doublet detection workflow
-  detect_doublets(sample_ch)
+  //detect_doublets(sample_ch)
 
   // Run the seurat conversion workflow
-  seurat_conversion(sample_ch)
+  //seurat_conversion(sample_ch)
 
   // Run the consensus cell type workflow
   cell_type_consensus(sample_ch)
@@ -71,7 +71,7 @@ workflow {
   cell_type_ewings(sample_ch.filter{ it[1] == "SCPCP000015" }, cell_type_consensus.out)
 
   // Run the infercnv gene order file workflow
-  infercnv_gene_order()
+  //infercnv_gene_order()
 
   // format and export json files with openscpca annotations
   // input expected to be sample id, project id, tsv files, annotation column, ontology column, module name

--- a/main.nf
+++ b/main.nf
@@ -9,6 +9,7 @@ include { seurat_conversion } from './modules/seurat-conversion'
 include { cell_type_consensus } from './modules/cell-type-consensus'
 include { cell_type_ewings } from './modules/cell-type-ewings'
 include { infercnv_gene_order } from './modules/infercnv-gene-order'
+include { export_annotations } from './modules/export-annotations'
 
 // **** Parameter checks ****
 include { validateParameters; paramsSummaryLog } from 'plugin/nf-schema'
@@ -71,4 +72,10 @@ workflow {
 
   // Run the infercnv gene order file workflow
   infercnv_gene_order()
+
+  // format and export json files with openscpca annotations
+  // input expected to be sample id, project id, tsv files, annotation column, ontology column, module name
+  // mix outputs from all cell type modules first
+  export_ch = cell_type_ewings.out.celltypes
+  export_annotations(export_ch)
 }

--- a/main.nf
+++ b/main.nf
@@ -81,9 +81,6 @@ workflow {
   // only runs on SCPCP000015
   cell_type_ewings(sample_ch.filter{ it[1] == "SCPCP000015" }, cell_type_consensus.out)
 
-  // Run the infercnv gene order file workflow
-  infercnv_gene_order()
-
   // Run the cell type neuroblastoma 04 workflow
   // only runs on SCPCP000004
   cell_type_neuroblastoma_04(sample_ch.filter{ it[1] == "SCPCP000004" })

--- a/main.nf
+++ b/main.nf
@@ -78,7 +78,8 @@ workflow {
 
   // format and export json files with openscpca annotations
   // input expected to be sample id, project id, tsv files, annotation meta
-  // annotation meta should be [module name, annotation column, ontology column]
+  // annotation meta should be a groovy map (dictionary) containing at least `module_name:` and  `annotation_column:` keys.
+  // The optional key `ontology_column:` will also be used if provided.
   // mix outputs from all cell type modules first
   export_ch = cell_type_ewings.out.celltypes
   export_annotations(export_ch)

--- a/modules/cell-type-ewings/main.nf
+++ b/modules/cell-type-ewings/main.nf
@@ -153,12 +153,14 @@ workflow cell_type_ewings {
         sample_id,
         project_id,
         assignment_files,
-        "ewing_annotation", // annotation column
-        "ewing_ontology", // ontology column
-        "cell-type-ewings" // module name
+        { // annotation metadata
+          module_name: "cell-type-ewings", 
+          annotation_column: "ewing_annotation", 
+          ontology_column: "ewing_ontology" 
+        }
       )}
 
   emit:
     aucell = ewing_aucell.out // [sample_id, project_id, [aucell output files], [mean gene expression files]]
-    celltypes = celltype_output_ch // [sample_id, project_id, [cell type assignment files], annotation column, ontology column, module name]
+    celltypes = celltype_output_ch // [sample_id, project_id, [cell type assignment files], annotation_metadata]
 }

--- a/modules/cell-type-ewings/main.nf
+++ b/modules/cell-type-ewings/main.nf
@@ -147,7 +147,18 @@ workflow cell_type_ewings {
     // assign cell types
     ewing_assign_celltypes(assign_ch, file(params.cell_type_ewings_auc_thresholds_file))
 
+    // add ewing specific metadata to output tuple
+    celltype_output_ch = ewing_assign_celltypes.out
+      .map{ sample_id, project_id, assignment_files -> tuple(
+        sample_id,
+        project_id,
+        assignment_files,
+        "ewing_annotation", // annotation column
+        "ewing_ontology", // ontology column
+        "cell-type-ewings" // module name
+      )}
+
   emit:
     aucell = ewing_aucell.out // [sample_id, project_id, [aucell output files], [mean gene expression files]]
-    celltypes = ewing_assign_celltypes.out // [sample_id, project_id, [cell type assignment files]]
+    celltypes = celltype_output_ch // [sample_id, project_id, [cell type assignment files], annotation column, ontology column, module name]
 }

--- a/modules/cell-type-ewings/main.nf
+++ b/modules/cell-type-ewings/main.nf
@@ -153,11 +153,11 @@ workflow cell_type_ewings {
         sample_id,
         project_id,
         assignment_files,
-        { // annotation metadata
-          module_name: "cell-type-ewings", 
-          annotation_column: "ewing_annotation", 
-          ontology_column: "ewing_ontology" 
-        }
+        [ // annotation metadata
+          module_name: "cell-type-ewings",
+          annotation_column: "ewing_annotation",
+          ontology_column: "ewing_ontology"
+        ]
       )}
 
   emit:

--- a/modules/export-annotations/README.md
+++ b/modules/export-annotations/README.md
@@ -1,0 +1,13 @@
+This module exports annotations from cell type modules in a uniform format to a public s3 bucket for use in other applications.
+Annotations can be found in `s3://openscpca-celltype-annotations-public-access`.
+
+For each library, a JSON file is exported with the following information:
+
+| | |
+| -- | -- |
+| `barcodes` | An array of unique cell barcodes |
+| `openscpca_celltype_annotation` | An array of cell type annotations assigned in `OpenScPCA-nf` |
+| `openscpca_celltype_ontology` | An array of Cell Ontology identifiers associated with the cell type annotation. If no Cell Ontology identifiers are assigned, this will be `NA` |
+| `module_name` | Name of the original analysis module used to assign cell type annotations in `OpenScPCA-analysis` |
+| `openscpca_nf_version` | Version of `OpenScPCA-nf` |
+| `release_date` | Release date of input ScPCA data |

--- a/modules/export-annotations/main.nf
+++ b/modules/export-annotations/main.nf
@@ -24,9 +24,8 @@ process format_annotations {
     ontology_included = "${ontology_column}" != "NONE"
     """
     for library_id in ${library_ids.join(" ")};do
-      # get the input and output files for the library id
+      # get the input files for the library id
       annotations_file=\$(ls ${annotations_tsv_files} | grep "\${library_id}")
-      json_file=\$(ls ${json_files} | grep "\${library_id}")
 
       export-celltype-json.R \
         --annotations_tsv_file \$annotations_file \
@@ -35,7 +34,7 @@ process format_annotations {
         --module_name ${module_name} \
         --release_date ${params.release_prefix} \
         --openscpca_nf_version ${workflow.manifest.version} \
-        --output_json_file \$json_file
+        --output_json_file \${library_id}_openscpca-annotations.json
     done
     """
 

--- a/modules/export-annotations/main.nf
+++ b/modules/export-annotations/main.nf
@@ -18,7 +18,6 @@ process format_annotations {
           path("*_openscpca-annotations.json")
   script:
     library_ids = annotations_tsv_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
-    json_files = library_ids.collect{"${it}_openscpca-annotations.json"}
     """
     for library_id in ${library_ids.join(" ")};do
       # get the input files for the library id
@@ -37,7 +36,6 @@ process format_annotations {
 
   stub:
     library_ids = annotations_tsv_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
-    json_files = library_ids.collect{"${it}_openscpca-annotations.json"}
     """
     for library_id in ${library_ids.join(" ")};do
       touch \${library_id}_openscpca-annotations.json

--- a/modules/export-annotations/main.nf
+++ b/modules/export-annotations/main.nf
@@ -33,7 +33,7 @@ process format_annotations {
         --annotation_column ${annotation_column} \
         ${ontology_included ? "--ontology_column  ${ontology_column}" : ''} \
         --module_name ${module_name} \
-        --release_data ${params.release_prefix} \
+        --release_date ${params.release_prefix} \
         --openscpca_nf_version ${workflow.manifest.version} \
         --output_json_file \$json_file
     done

--- a/modules/export-annotations/main.nf
+++ b/modules/export-annotations/main.nf
@@ -30,8 +30,8 @@ process format_annotations {
 
       export-celltype-json.R \
         --annotations_tsv_file \$annotations_file \
-        --annotation_column ${annotation_column} \
-        ${ontology_included ? "--ontology_column  ${ontology_column}" : ''} \
+        --annotation_column "${annotation_column}" \
+        ${ontology_included ? "--ontology_column  '${ontology_column}'" : ''} \
         --module_name ${module_name} \
         --release_date ${params.release_prefix} \
         --openscpca_nf_version ${workflow.manifest.version} \

--- a/modules/export-annotations/main.nf
+++ b/modules/export-annotations/main.nf
@@ -38,6 +38,15 @@ process format_annotations {
         --output_json_file \$json_file
     done
     """
+
+  stub:
+    library_ids = annotations_tsv_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
+    json_files = library_ids.collect{"${it}_openscpca-annotations.json"}
+    """
+    for library_id in ${library_ids.join(" ")};do
+      touch \${library_id}_openscpca-annotations.json
+    done
+    """
 }
 
 workflow export_annotations {

--- a/modules/export-annotations/main.nf
+++ b/modules/export-annotations/main.nf
@@ -1,0 +1,52 @@
+#!/usr/bin/env nextflow
+
+// Workflow to format and export openscpca annotations
+
+process format_annotations {
+  container params.scpcatools_slim_container
+  tag "${sample_id}"
+  label 'mem_8'
+  publishDir "${params.annotations_bucket}/${params.release_prefix}/${project_id}/${sample_id}", mode: 'copy'
+  input:
+    tuple val(sample_id),
+          val(project_id),
+          path(annotations_tsv_files),
+          val(annotation_column),
+          val(ontology_column),
+          val(module_name)
+  output:
+    tuple val(sample_id),
+          val(project_id),
+          path(json_files)
+  script:
+    library_ids = annotations_tsv_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
+    json_files = library_ids.collect{"${it}_openscpca-annotations.json"}
+    ontology_included = "${ontology_column}" != "NONE"
+    """
+    for library_id in ${library_ids.join(" ")};do
+      # get the input and output files for the library id
+      annotations_file=\$(ls ${annotations_tsv_files} | grep "\${library_id}")
+      json_file=\$(ls ${json_files} | grep "\${library_id}")
+
+      export-celltype-json.R \
+        --annotations_tsv_file \$annotations_file \
+        --annotation_column ${annotation_column} \
+        ${ontology_included ? "--ontology_column  ${ontology_column}" : ''} \
+        --module_name ${module_name} \
+        --release_data ${params.release_prefix} \
+        --openscpca_nf_version ${workflow.manifest.version} \
+        --output_json_file \$json_file
+    done
+    """
+}
+
+workflow export_annotations {
+  take:
+    celltype_ch  // [sample_id, project_id, [cell type assignment files], annotation column, ontology column, module name]
+  main:
+    // export json
+    format_annotations(celltype_ch)
+
+  emit:
+    format_annotations.out // [sample id, project id, annotations json]
+}

--- a/modules/export-annotations/resources/usr/bin/export-celltype-json.R
+++ b/modules/export-annotations/resources/usr/bin/export-celltype-json.R
@@ -1,0 +1,98 @@
+#!/usr/bin/env Rscript
+
+# This script is used to create a JSON file of annotations for a single library
+# JSON file will include barcodes, annotation column, ontology column (if provided),
+# openscpca-nf version, data release data, and module name
+
+library(optparse)
+
+option_list <- list(
+  make_option(
+    opt_str = c("--annotations_tsv_file"),
+    type = "character",
+    help = "Path to TSV file with cell type annotations"
+  ),
+  make_option(
+    opt_str = c("--annotation_column"),
+    type = "character",
+    help = "Name of the column containing the cell type annotations to use for openscpca_celltype_annotation"
+  ),
+  make_option(
+    opt_str = c("--ontology_column"),
+    default = "",
+    type = "character",
+    help = "Name of the column containing the cell type ontology IDs to use for openscpca_celltype_ontology"
+  ),
+  make_option(
+    opt_str = c("--module_name"),
+    type = "character",
+    help = "Name of original module in OpenScPCA-analysis"
+  ),
+  make_option(
+    opt_str = c("--release_date"),
+    type = "character",
+    help = "Release date of data used when generating annotations"
+  ),
+  make_option(
+    opt_str = c("--openscpca_nf_version"),
+    type = "character",
+    help = "Version of OpenScPCA-nf workflow"
+  ),
+  make_option(
+    opt_str = "--output_json_file",
+    type = "character",
+    help = "Path to JSON file to save cell type annotations"
+  )
+)
+
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# Set up -----------------------------------------------------------------------
+
+# make sure input/output exist
+stopifnot(
+  "annotations TSV file does not exist" = file.exists(opt$annotations_tsv_file),
+  "annotation column must be provided" = !is.null(opt$annotation_column),
+  "module name must be provided" = !is.null(opt$module_name),
+  "release date must be provided" = !is.null(opt$release_date),
+  "openscpca-nf version must be provided" = !is.null(opt$openscpca_nf_version),
+  "output json file must end in .json" = stringr::str_ends(opt$output_json_file, "\\.json")
+)
+
+# read in annotations
+annotations_df <- readr::read_tsv(opt$annotations_tsv_file)
+
+# check that barcodes and annotation column exist
+stopifnot(
+  "barcodes column must be present in provided TSV file" = "barcodes" %in% colnames(annotations_df),
+  "annotation column is not present in provided TSV file" = opt$annotation_column %in% colnames(annotations_df)
+)
+
+# check for ontology ids if provided
+if (!is.null(opt$ontology_column)) {
+  stopifnot(
+    "ontology column is not present in provided TSV file" = opt$ontology_column %in% colnames(annotations_df)
+  )
+  ontology_ids <- annotations_df[[opt$ontology_column]]
+} else {
+  ontology_ids <- NA
+}
+
+# build json contents
+json_contents <- list(
+  barcodes = annotations_df$barcodes,
+  openscpca_celltype_annotation = annotations_df[[opt$annotation_column]],
+  openscpca_celltype_ontology = ontology_ids,
+  module_name = opt$module_name,
+  openscpca_nf_version = opt$openscpca_nf_version,
+  release_date = opt$release_date
+)
+
+# export json file
+jsonlite::write_json(
+  json_contents,
+  path = opt$output_json_file,
+  auto_unbox = TRUE,
+  pretty = TRUE
+)

--- a/modules/export-annotations/resources/usr/bin/export-celltype-json.R
+++ b/modules/export-annotations/resources/usr/bin/export-celltype-json.R
@@ -62,7 +62,6 @@ stopifnot(
 
 # read in annotations
 annotations_df <- readr::read_tsv(opt$annotations_tsv_file)
-message("Annotations read in")
 
 # check that barcodes and annotation column exist
 stopifnot(
@@ -90,14 +89,11 @@ json_contents <- list(
   release_date = opt$release_date
 )
 
-print(json_contents)
-message("Json created")
-
 # export json file
 jsonlite::write_json(
   json_contents,
   path = opt$output_json_file,
+  simplifyVector = TRUE,
   auto_unbox = TRUE,
   pretty = TRUE
 )
-message("Json exported")

--- a/modules/export-annotations/resources/usr/bin/export-celltype-json.R
+++ b/modules/export-annotations/resources/usr/bin/export-celltype-json.R
@@ -81,12 +81,12 @@ if (!is.null(opt$ontology_column)) {
 
 # build json contents
 json_contents <- list(
-  barcodes = annotations_df$barcodes,
-  openscpca_celltype_annotation = annotations_df[[opt$annotation_column]],
-  openscpca_celltype_ontology = ontology_ids,
   module_name = opt$module_name,
   openscpca_nf_version = opt$openscpca_nf_version,
-  release_date = opt$release_date
+  release_date = opt$release_date,
+  barcodes = annotations_df$barcodes,
+  openscpca_celltype_annotation = annotations_df[[opt$annotation_column]],
+  openscpca_celltype_ontology = ontology_ids
 )
 
 # export json file

--- a/modules/export-annotations/resources/usr/bin/export-celltype-json.R
+++ b/modules/export-annotations/resources/usr/bin/export-celltype-json.R
@@ -62,6 +62,7 @@ stopifnot(
 
 # read in annotations
 annotations_df <- readr::read_tsv(opt$annotations_tsv_file)
+message("Annotations read in")
 
 # check that barcodes and annotation column exist
 stopifnot(
@@ -89,6 +90,9 @@ json_contents <- list(
   release_date = opt$release_date
 )
 
+print(json_contents)
+message("Json created")
+
 # export json file
 jsonlite::write_json(
   json_contents,
@@ -96,3 +100,4 @@ jsonlite::write_json(
   auto_unbox = TRUE,
   pretty = TRUE
 )
+message("Json exported")

--- a/nextflow.config
+++ b/nextflow.config
@@ -112,6 +112,7 @@ profiles {
       release_bucket = "s3://openscpca-test-data-release-public-access" // test bucket
       results_bucket = "test/stub/results" // no output
       sim_bucket = "test/stub/simulated" // local output
+      annotations_bucket = "test/stub/annotations" // no output
       project = "SCPCP000012" // a small project
 
       // Override full NBAtlas with empty file for stub testing

--- a/nextflow.config
+++ b/nextflow.config
@@ -112,7 +112,7 @@ profiles {
       release_bucket = "s3://openscpca-test-data-release-public-access" // test bucket
       results_bucket = "test/stub/results" // no output
       sim_bucket = "test/stub/simulated" // local output
-      annotations_bucket = "test/stub/annotations" // no output
+      annotations_bucket = "test/stub/annotations" // local output
       project = "SCPCP000012" // a small project
 
       // Override full NBAtlas with empty file for stub testing

--- a/nextflow.config
+++ b/nextflow.config
@@ -44,6 +44,7 @@ params {
   release_bucket = "s3://openscpca-data-release"
   results_bucket = "s3://openscpca-nf-workflow-results-staging"
   sim_bucket = "s3://openscpca-test-data-release-staging"
+  annotations_bucket = "s3://openscpca-celltype-annotations-public-access"
   project = "all"
 
   // URIs to reference files

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -36,6 +36,12 @@
           "description": "Base URI for simulated data output",
           "help_text": "Standard configurations will use an S3 bucket, but local paths can also be used."
         },
+        "annotations_bucket": {
+          "type": "string",
+          "default": "s3://openscpca-celltype-annotations-public-access",
+          "description": "Base URI for saving cell type annotations output",
+          "help_text": "Standard configurations will use an S3 bucket, but local paths can also be used."
+        },
         "project": {
           "type": "string",
           "default": "all",


### PR DESCRIPTION
Closes #161 

Here I'm adding a module to be used for formatting and exporting annotations from OpenScPCA as JSON files to use as input to `scpca-nf`. The new module is named `export_annotations` and takes as input a channel with TSV files from annotation modules. It just runs one process which is an R script to create the JSON file using the TSV file as input. The JSON file includes an array of barcodes, cell type annotations, ontology IDs if present, workflow version, release date and the name of the original analysis module. These files are saved to the annotations bucket within the folder corresponding to that data release, following the same organization as the main workflow results output. 

I made this into a separate module that gets run at the end using inputs from the annotation modules. This is currently just Ewings, but the idea would be to combine all the annotation outputs into a single channel to use as input to this module. Alternatively, I could run this as a separate process at the end of each annotation module and not in the main workflow, but I thought that would be harder to maintain. 

I think the main thing we should figure out here is the approach to passing in the column names for where the annotations are in each TSV. Currently I have it set up so there are two arguments to the script, one for the annotation column and one for the ontology column. This is because right now, we don't have a standard naming convention for what the columns should be named when they are output in the TSV files from an annotation module. For example, the Ewing columns are `ewing_annotation` and `ewing_ontology`. I think there are a few different approaches we could take here: 

- Leave the column names as is and specify what columns to use with arguments as I've done here. This requires us to pass in the column names in the input channel to this workflow. 
- Keep arguments for the column names but make those column names parameters to the workflow rather than hardcoding them in the annotation module. This would require some updates to the Rscript for assigning Ewing cell typing but might be easier long term to have the names of the columns in one place. 
- Require the annotations that we want to port over to be in a specific `openscpca_celltype_annotation` column in the TSV files and remove the arguments alltogether. With this option additional annotation columns can be present, but whatever is getting ported over must be in those columns. 
  - My only hesitation with this option is that these columns don't exist yet for the Ewing data. I would want to add these as additional columns with the existing Ewing output rather than overwrite the columns since there is code in `OpenScPCA-analysis` that uses these annotation columns. 

Another thing I wanted to note is that I think we should set a standard expectation of what the output tuples and TSV files should be from cell type annotation modules so that they can be used as input to format the annotations. Once we decide what that is we should update the docs for porting modules to include that information. 

I did test this and successfully made JSON files that can be easily read into R as a data frame. 