### PR TITLE
Add script and process to train SingleR model

### DIFF
--- a/config/module_params.config
+++ b/config/module_params.config
@@ -27,6 +27,6 @@ params{
   // TODO: Replace these files with tagged links once we have a new OpenScPCA-analysis tag
   cell_type_nb_04_validation_group_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-consensus/references/consensus-validation-groups.tsv'
   cell_type_nb_04_label_map_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-label-map.tsv'
-  cell_type_nb_04_ontology_map_fie = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-ontology-ids.tsv'
+  cell_type_nb_04_ontology_map_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-ontology-ids.tsv'
 
 }

--- a/modules/cell-type-neuroblastoma-04/README.md
+++ b/modules/cell-type-neuroblastoma-04/README.md
@@ -4,4 +4,5 @@ Scripts are derived from the the `cell-type-neuroblastoma-04` module of the [Ope
 
 Links to specific original scripts used in this module:
 
-* `00-convert-nbatlas.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/ad3b3c6ac6bcb7154058e4f725250dc56523caa8/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R>
+* `00_convert-nbatlas.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/ad3b3c6ac6bcb7154058e4f725250dc56523caa8/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R>
+* `01_train-singler-model.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/7c0acea43b6cfc26da75a3a1dbd3558a0d9229ed/analyses/cell-type-neuroblastoma-04/scripts/01_train-singler-model.R>

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -6,14 +6,12 @@
 process convert_nbatlas {
   container params.cell_type_nb_04_container
   label 'mem_8'
-  // TODO: Remove publishDir after initial PR
-  publishDir "${params.results_bucket}/${params.release_prefix}/cell-type-neuroblastoma-04"
   input:
     path nbatlas_seurat_file
   output:
-    path nbatlas_sce_file
-    path nbatlas_anndata_file
-    path nbatlas_hvg_file
+    tuple path(nbatlas_sce_file),
+          path(nbatlas_anndata_file),
+          path(nbatlas_hvg_file)
   script:
     nbatlas_sce_file = "nbatlas_sce.rds"
     nbatlas_anndata_file = "nbatlas_anndata.h5ad"
@@ -27,12 +25,37 @@ process convert_nbatlas {
     """
   stub:
     nbatlas_sce_file = "nbatlas_sce.rds"
-    nbatlas_anndata_file = "nbatlas_anndata.rds"
+    nbatlas_anndata_file = "nbatlas_anndata.h5ad"
     nbatlas_hvg_file = "nbatlas_hvg.txt.gz"
     """
     touch ${nbatlas_sce_file}
     touch ${nbatlas_anndata_file}
     touch ${nbatlas_hvg_file}
+    """
+}
+
+
+process train_singler_model {
+  container params.cell_type_nb_04_container
+  label 'mem_8'
+  publishDir "${params.results_bucket}/${params.release_prefix}/cell-type-neuroblastoma-04"
+  input:
+    tuple path(nbatlas_sce_file),
+          path(gtf_file)
+  output:
+    path nbatlas_singler_model
+  script:
+    nbatlas_singler_model = "nbatlas_singler_model.rds"
+    """
+    train-singler-model.R \
+      --nbatlas_file ${nbatlas_sce_file} \
+      --gtf_file ${gtf_file} \
+      --singler_model_file ${nbatlas_singler_model}
+    """
+  stub:
+    nbatlas_singler_model = "nbatlas_singler_model.rds"
+    """
+    touch ${nbatlas_singler_model}
     """
 }
 
@@ -53,4 +76,16 @@ workflow cell_type_neuroblastoma_04 {
     // returns [nbatlas_sce_file, nbatlas_anndata_file, nbatlas_hvg_file]
     convert_nbatlas(file(params.cell_type_nb_04_nbatlas_url))
 
+    // creates [nbatlas_sce_file, gtf_file]
+    singler_train_ch = convert_nbatlas.out
+      .map{ nbatlas_sce_file, nbatlas_anndata_file, nbatlas_hvg_file ->
+        return [nbatlas_sce_file, file(params.gtf_file)]
+      }
+
+    // train Singler model
+    train_singler_model(singler_train_ch)
+
+    // Emit temporarily for testing while workflow is being developed
+    emit:
+      train_singler_model.out.nbatlas_singler_model
 }

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -87,5 +87,5 @@ workflow cell_type_neuroblastoma_04 {
 
     // Emit temporarily for testing while workflow is being developed
     emit:
-      train_singler_model.out.nbatlas_singler_model
+      train_singler_model.out
 }

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/train-singler-model.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/train-singler-model.R
@@ -20,19 +20,18 @@ option_list <- list(
   make_option(
     opt_str = c("--nbatlas_sce"),
     type = "character",
-    default = "~/ALSF/open-scpca/OpenScPCA-analysis/analyses/cell-type-neuroblastoma-04/references/NBAtlas_sce.rds",
+    default = "",
     help = "Path to an NBAtlas object in SCE format"
   ),
   make_option(
     opt_str = c("--gtf_file"),
     type = "character",
-    default = "~/Desktop/Homo_sapiens.GRCh38.104.gtf.gz",
+    default = "",
     help = "Path to GTF file for determining genes to restrict to"
   ),
   make_option(
     opt_str = c("--singler_model_file"),
     type = "character",
-    default = "model.rds",
     help = "Path to RDS file to save trained SingleR model"
   ),
   make_option(
@@ -53,7 +52,8 @@ option_list <- list(
 opts <- parse_args(OptionParser(option_list = option_list))
 stopifnot(
   "nbatlas_sce does not exist" = file.exists(opts$nbatlas_sce),
-  "gtf_file does not exist" = file.exists(opts$gtf_file)
+  "gtf_file does not exist" = file.exists(opts$gtf_file),
+  "singler_model_file must be specified" = !is.null(opts$singler_model_file)
 )
 set.seed(opts$seed)
 

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/train-singler-model.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/train-singler-model.R
@@ -94,4 +94,8 @@ nbatlas_trained <- SingleR::trainSingleR(
   aggr.ref = TRUE,
   BPPARAM = bp_param
 )
-readr::write_rds(nbatlas_trained, opts$singler_model_file)
+readr::write_rds(
+  nbatlas_trained,
+  opts$singler_model_file,
+  compress = "gz"
+)

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/train-singler-model.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/train-singler-model.R
@@ -1,0 +1,97 @@
+#!/usr/bin/env Rscript
+#
+# This script trains a SingleR model from a given NBAtlas object
+# The script restricts genes in the model based on the intersection
+# between NBAtlas gene symbols and gene symbols in the GTF, which was used to add
+# gene symbols to SCE objects: https://github.com/AlexsLemonade/scpca-nf/blob/8a85702f7c3e616d1d73335d4139d3c72fabfd4e/bin/generate_unfiltered_sce.R#L181
+#
+# This script was adapted from:
+# https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/7c0acea43b6cfc26da75a3a1dbd3558a0d9229ed/analyses/cell-type-neuroblastoma-04/scripts/01_train-singler-model.R
+
+suppressWarnings({
+  suppressPackageStartupMessages({
+    library(optparse)
+    library(SingleCellExperiment)
+  })
+})
+
+
+option_list <- list(
+  make_option(
+    opt_str = c("--nbatlas_sce"),
+    type = "character",
+    default = "~/ALSF/open-scpca/OpenScPCA-analysis/analyses/cell-type-neuroblastoma-04/references/NBAtlas_sce.rds",
+    help = "Path to an NBAtlas object in SCE format"
+  ),
+  make_option(
+    opt_str = c("--gtf_file"),
+    type = "character",
+    default = "~/Desktop/Homo_sapiens.GRCh38.104.gtf.gz",
+    help = "Path to GTF file for determining genes to restrict to"
+  ),
+  make_option(
+    opt_str = c("--singler_model_file"),
+    type = "character",
+    default = "model.rds",
+    help = "Path to RDS file to save trained SingleR model"
+  ),
+  make_option(
+    opt_str = c("--threads"),
+    type = "integer",
+    default = 4,
+    help = "Number of threads for SingleR to use"
+  ),
+  make_option(
+    opt_str = c("--seed"),
+    type = "integer",
+    default = 2025,
+    help = "Random seed"
+  )
+)
+
+# Parse options and check arguments
+opts <- parse_args(OptionParser(option_list = option_list))
+stopifnot(
+  "nbatlas_sce does not exist" = file.exists(opts$nbatlas_sce),
+  "gtf_file does not exist" = file.exists(opts$gtf_file)
+)
+set.seed(opts$seed)
+
+if (opts$threads == 1) {
+  bp_param <- BiocParallel::SerialParam()
+} else {
+  bp_param <- BiocParallel::MulticoreParam(opts$threads)
+}
+
+# Read atlas
+nbatlas_sce <- readRDS(opts$nbatlas_sce)
+
+# Read gtf; only genes are needed
+gtf <- rtracklayer::import(opts$gtf_file, feature.type = "gene")
+
+# Get all gene symbols present in ScPCA objects
+# Source: https://github.com/AlexsLemonade/scpcaTools/blob/f56de55215e95eb6aac1db509e27081adaf5c35a/R/add_gene_symbols.R#L27
+scpca_gene_symbols <- gtf |>
+  as.data.frame() |>
+  dplyr::select(gene_id, gene_name) |>
+  tidyr::drop_na(gene_name) |>
+  dplyr::distinct() |>
+  dplyr::pull(gene_name)
+
+# Define restrict vector for model training as intersection of ScPCA
+# and NBAtlas gene symbols
+restrict_genes <- intersect(
+  scpca_gene_symbols,
+  rownames(nbatlas_sce)
+)
+
+# Create and export an aggregated version of the reference
+nbatlas_trained <- SingleR::trainSingleR(
+  ref = nbatlas_sce,
+  labels = nbatlas_sce$Cell_type_wImmuneZoomAnnot,
+  de.method = "wilcox",
+  restrict = restrict_genes,
+  aggr.ref = TRUE,
+  BPPARAM = bp_param
+)
+readr::write_rds(nbatlas_trained, opts$singler_model_file)

--- a/nextflow.config
+++ b/nextflow.config
@@ -114,7 +114,7 @@ profiles {
       project = "SCPCP000012" // a small project
 
       // Override full NBAtlas with empty file for stub testing
-      cell_type_nb_04_nbatlas_url = "${projectDir}/modules/cell-type-neuroblastoma-04/resources/NBAtlas_test.rds"
+      cell_type_nb_04_nbatlas_url = "${projectDir}/modules/cell-type-neuroblastoma-04/resources/test/NBAtlas_test.rds"
     }
     process {
       executor = 'local'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -209,7 +209,7 @@
           "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-consensus/references/consensus-validation-groups.tsv",
           "description": "Path or URL to TSV mapping consensus cell types to broad validation groups"
         },
-        "cell_type_nb_04_ontology_map_fie": {
+        "cell_type_nb_04_ontology_map_file": {
           "type": "string",
           "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-neuroblastoma-04/references/nbatlas-ontology-ids.tsv",
           "description": "Path or URL to TSV mapping NBAtlas labels to ontology ids"


### PR DESCRIPTION
Closes #165 

This PR adds the process and R script to train the SingleR model for NB annotations. Part of this script entails finding the intersecting gene symbols between the NBAtlas reference and ScPCA objects; previously we did this using an SCE to help, but in this implementation I'm using the GTF file to get those symbols. I also caught/fixed a couple param and other typos while locally testing.

For testing purposes, I'm temporarily emitting this output as well, but this will go away as development proceeds!