### PR TITLE
Add process/script to train reference scanvi model

### DIFF
--- a/modules/cell-type-neuroblastoma-04/README.md
+++ b/modules/cell-type-neuroblastoma-04/README.md
@@ -6,3 +6,4 @@ Links to specific original scripts used in this module:
 
 * `00_convert-nbatlas.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/ad3b3c6ac6bcb7154058e4f725250dc56523caa8/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R>
 * `01_train-singler-model.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/7c0acea43b6cfc26da75a3a1dbd3558a0d9229ed/analyses/cell-type-neuroblastoma-04/scripts/01_train-singler-model.R>
+* `03a_train-scanvi-model.py`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/82547028b5a9555d8cee40f6c1883015c990cc4f/analyses/cell-type-neuroblastoma-04/scripts/03a_train-scanvi-model.py>

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -61,7 +61,7 @@ process train_singler_model {
 
 process train_scanvi_model {
   container params.cell_type_nb_04_container
-  label 'mem_8'
+  label 'mem_16'
   input:
     path nbatlas_anndata_file
   output:

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -10,8 +10,8 @@ process convert_nbatlas {
     path nbatlas_seurat_file
   output:
     path nbatlas_sce_file, emit: sce
-    tuple path(nbatlas_anndata_file),
-          path(nbatlas_hvg_file), emit: anndata
+    path nbatlas_anndata_file, emit: anndata
+    path nbatlas_hvg_file, emit: hvg_file
   script:
     nbatlas_sce_file = "nbatlas_sce.rds"
     nbatlas_anndata_file = "nbatlas_anndata.h5ad"
@@ -59,6 +59,31 @@ process train_singler_model {
 }
 
 
+process train_scanvi_model {
+  container params.cell_type_nb_04_container
+  label 'mem_8'
+  input:
+    path nbatlas_anndata_file
+  output:
+    path scanvi_ref_model_dir
+  script:
+    scanvi_ref_model_dir = "scanvi_ref_model_dir"
+    """
+    train-scanvi-model.R \
+      --reference_file ${nbatlas_anndata_file} \
+      --reference_scanvi_model_dir ${scanvi_ref_model_dir}
+    """
+  stub:
+    scanvi_ref_model_dir = "scanvi_ref_model_dir"
+    """
+    mkdir ${scanvi_ref_model_dir}
+    # touch expected model files
+    touch ${scanvi_ref_model_dir}/adata.h5ad
+    touch ${scanvi_ref_model_dir}/model.pt
+    """
+}
+
+
 
 workflow cell_type_neuroblastoma_04 {
   take:
@@ -72,8 +97,14 @@ workflow cell_type_neuroblastoma_04 {
       }
 
     // convert NBAtlas to SCE and AnnData objects
+    // emits: sce, anndata, hvg_file
     convert_nbatlas(file(params.cell_type_nb_04_nbatlas_url))
 
-    // train Singler model
+    // train SingleR model
+    // outputs the singler model file
     train_singler_model(convert_nbatlas.out.sce, file(params.gtf_file))
+
+    // train scANVI model
+    // outputs the scanvi model directory
+    train_scanvi_model(convert_nbatlas.out.anndata)
 }

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/train-scanvi-model.py
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/train-scanvi-model.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+# Script to train a scANVI/scArches model from the NBAtlas reference
+# This script was adapted from:
+# https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/82547028b5a9555d8cee40f6c1883015c990cc4f/analyses/cell-type-neuroblastoma-04/scripts/03a_train-scanvi-model.py
+
+import argparse
+import sys
+from pathlib import Path
+
+import anndata
+from scipy.sparse import csr_matrix
+import scvi
+import torch
+
+# Define constants
+BATCH_KEY = "Sample"
+COVARIATE_KEYS = [
+    "Assay",
+    "Platform",
+]
+CELLTYPE_COLUMN = "Cell_type_wImmuneZoomAnnot"
+CELL_ID_KEY = "cell_id"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Train a scANVI/scArches model from the NBAtlas reference.",
+    )
+    parser.add_argument(
+        "--reference_file",
+        type=Path,
+        required=True,
+        help="Path to the input NBAtlas reference file",
+    )
+    parser.add_argument(
+        "--reference_scanvi_model_dir",
+        type=Path,
+        required=True,
+        help="Path to directory where the scANVI model trained on the reference object will be saved."
+        " This directory will be created at export.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=2025,
+        help="Random seed to ensure reproducibility",
+    )
+    arg = parser.parse_args()
+
+    ################################################
+    ########### Input argument checks ##############
+    ################################################
+    arg_error = False
+
+    # Check that the input file exists
+    if not arg.reference_file.is_file():
+        print(
+            f"The provided input reference file could not be found at: {arg.reference_file}.",
+            file=sys.stderr,
+        )
+        arg_error = True
+
+    # Read and check that the reference object has expected columns
+    reference = anndata.read_h5ad(arg.reference_file)
+    expected_columns = [BATCH_KEY, CELL_ID_KEY, CELLTYPE_COLUMN] + COVARIATE_KEYS
+
+    if not set(expected_columns).issubset(reference.obs.columns):
+        print(
+            f"The reference AnnData object is missing one or more expected columns: {set(expected_columns).difference(reference.obs.columns)}.",
+            file=sys.stderr,
+        )
+        arg_error = True
+
+    # Exit if error(s)
+    if arg_error:
+        sys.exit(1)
+
+    # Set seed for reproducibility
+    # torch commands are ignored if GPU not present
+    scvi.settings.seed = arg.seed  # inherited by numpy and torch
+    torch.cuda.manual_seed(arg.seed)
+    torch.cuda.manual_seed_all(arg.seed)
+
+    # Ensure anndata is using a sparse matrix for faster processing
+    reference.X = csr_matrix(reference.X)
+
+    ################################################
+    ######## SCVI reference model training #########
+    ################################################
+
+    scvi.model.SCVI.setup_anndata(
+        reference,
+        batch_key=BATCH_KEY,
+        categorical_covariate_keys=COVARIATE_KEYS,  # control for cell/nucleus and 10x2/3
+    )
+
+    scvi_model = scvi.model.SCVI(
+        reference,
+        # scArches parameters
+        # from: https://docs.scvi-tools.org/en/1.3.2/tutorials/notebooks/multimodal/scarches_scvi_tools.html#train-reference
+        use_layer_norm="both",
+        use_batch_norm="none",
+        encode_covariates=True,  # essential for scArches
+        dropout_rate=0.2,
+        n_layers=2,
+    )
+
+    # Train SCVI model; will automatically detect architecture to run on CPU or GPU
+    scvi_model.train()
+
+    ################################################
+    ####### scANVI reference model training ########
+    ################################################
+
+    scanvi_model = scvi.model.SCANVI.from_scvi_model(
+        scvi_model,
+        unlabeled_category="Unknown",  # will be used to set up query next; labels will start as `Unknown`
+        labels_key=CELLTYPE_COLUMN,
+    )
+    scanvi_model.train()
+
+    ################################################
+    ################ Export objects ################
+    ################################################
+
+    # Export the NBAtlas-trained scANVI model
+    scanvi_model.save(arg.reference_scanvi_model_dir, save_anndata=True, overwrite=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #167 

This PR adds the last "reference-building" step for the NB workflow, to train the reference scANVI/scArches model. I tested this locally emitting both the singler model file and scanvi _directory_ (scanvi creates a directory with 2 model files in it as its output) ✅ 

While implementing this, I realized I should split up the original `convert_nbatlas` output into 3, since the HVG file and anndata reference file don't actually go into the same process even though they are both scanvi. The anndata reference only goes into the training process, and the hvgs will only go into the forthcoming scanvi label transfer process. So, I tweaked that part as well.

Here are the main differences in the python script compared to its original version:
- Since we don't have to accommodate testing data, we can set the `CELLTYPE_COLUMN` as a constant to the tumor zoom column
- In the context of running this workflow, we can let it automatically choose the accelerator (cpu or gpu), so we don't need to specify an argument (its default accelerator is "auto"). One day if we have gpu, it would therefore be able to run still!
- I only export the model, which is a directory that scvi-tools creates on saving. We don't need to export (or calculate for that matter) the latent representation separately.