### PR TITLE
Assign neuroblastoma labels

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -57,17 +57,17 @@ workflow {
     .filter{ run_all || it[1] in project_ids }
 
 
-  // // Run the merge workflow
-  // merge_sce(sample_ch)
+  // Run the merge workflow
+  merge_sce(sample_ch)
 
-  // // Run the doublet detection workflow
-  // detect_doublets(sample_ch)
+  // Run the doublet detection workflow
+  detect_doublets(sample_ch)
 
-  // // Run the seurat conversion workflow
-  // seurat_conversion(sample_ch)
+  // Run the seurat conversion workflow
+  seurat_conversion(sample_ch)
 
-  // // Run the infercnv gene order file workflow
-  // infercnv_gene_order()
+  // Run the infercnv gene order file workflow
+  infercnv_gene_order()
 
   // Cell type annotation workflows //
 
@@ -75,7 +75,7 @@ workflow {
   cell_type_consensus(sample_ch)
 
   // run the scimilarity cell type workflow
-  // cell_type_scimilarity(sample_ch)
+  cell_type_scimilarity(sample_ch)
 
   // Run the cell type ewings workflow
   // only runs on SCPCP000015

--- a/main.nf
+++ b/main.nf
@@ -57,17 +57,17 @@ workflow {
     .filter{ run_all || it[1] in project_ids }
 
 
-  // Run the merge workflow
-  merge_sce(sample_ch)
+  // // Run the merge workflow
+  // merge_sce(sample_ch)
 
-  // Run the doublet detection workflow
-  detect_doublets(sample_ch)
+  // // Run the doublet detection workflow
+  // detect_doublets(sample_ch)
 
-  // Run the seurat conversion workflow
-  seurat_conversion(sample_ch)
+  // // Run the seurat conversion workflow
+  // seurat_conversion(sample_ch)
 
-  // Run the infercnv gene order file workflow
-  infercnv_gene_order()
+  // // Run the infercnv gene order file workflow
+  // infercnv_gene_order()
 
   // Cell type annotation workflows //
 
@@ -75,7 +75,7 @@ workflow {
   cell_type_consensus(sample_ch)
 
   // run the scimilarity cell type workflow
-  cell_type_scimilarity(sample_ch)
+  // cell_type_scimilarity(sample_ch)
 
   // Run the cell type ewings workflow
   // only runs on SCPCP000015

--- a/main.nf
+++ b/main.nf
@@ -83,7 +83,7 @@ workflow {
 
   // Run the cell type neuroblastoma 04 workflow
   // only runs on SCPCP000004
-  cell_type_neuroblastoma_04(sample_ch.filter{ it[1] == "SCPCP000004" })
+  cell_type_neuroblastoma_04(sample_ch.filter{ it[1] == "SCPCP000004" }, , cell_type_consensus.out)
 
   // format and export json files with openscpca annotations
   // input expected to be sample id, project id, tsv files, annotation meta

--- a/main.nf
+++ b/main.nf
@@ -83,7 +83,7 @@ workflow {
 
   // Run the cell type neuroblastoma 04 workflow
   // only runs on SCPCP000004
-  cell_type_neuroblastoma_04(sample_ch.filter{ it[1] == "SCPCP000004" }, , cell_type_consensus.out)
+  cell_type_neuroblastoma_04(sample_ch.filter{ it[1] == "SCPCP000004" }, cell_type_consensus.out)
 
   // format and export json files with openscpca annotations
   // input expected to be sample id, project id, tsv files, annotation meta

--- a/main.nf
+++ b/main.nf
@@ -91,5 +91,6 @@ workflow {
   // The optional key `ontology_column:` will also be used if provided.
   // mix outputs from all cell type modules first
   export_ch = cell_type_ewings.out.celltypes
+    .mix(cell_type_neuroblastoma_04.out.celltypes)
   export_annotations(export_ch)
 }

--- a/modules/cell-type-neuroblastoma-04/README.md
+++ b/modules/cell-type-neuroblastoma-04/README.md
@@ -2,7 +2,7 @@ This module assigns cell types to all Neuroblastoma samples in `SCPCP000004`.
 
 Scripts are derived from the the `cell-type-neuroblastoma-04` module of the [OpenScPCA-analysis](https://github.com/AlexsLemonade/OpenScPCA-analysis) repository.
 
-Links to specific original scripts used in this module:
+Links to specific original scripts and notebooks used in this module:
 
 * `00_convert-nbatlas.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/ad3b3c6ac6bcb7154058e4f725250dc56523caa8/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R>
 * `01_train-singler-model.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/7c0acea43b6cfc26da75a3a1dbd3558a0d9229ed/analyses/cell-type-neuroblastoma-04/scripts/01_train-singler-model.R>
@@ -10,3 +10,4 @@ Links to specific original scripts used in this module:
 * `03a_train-scanvi-model.py`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/82547028b5a9555d8cee40f6c1883015c990cc4f/analyses/cell-type-neuroblastoma-04/scripts/03a_train-scanvi-model.py>
 * `03b_prepare-scanvi-query.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/82547028b5a9555d8cee40f6c1883015c990cc4f/analyses/cell-type-neuroblastoma-04/scripts/03b_prepare-scanvi-query.R>
 * `03c_run-scanvi-label-transfer.py`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/82547028b5a9555d8cee40f6c1883015c990cc4f/analyses/cell-type-neuroblastoma-04/scripts/03c_run-scanvi-label-transfer.py>
+* `final-annotation.Rmd`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/82547028b5a9555d8cee40f6c1883015c990cc4f/analyses/cell-type-neuroblastoma-04/final-annotation.Rmd>

--- a/modules/cell-type-neuroblastoma-04/README.md
+++ b/modules/cell-type-neuroblastoma-04/README.md
@@ -1,7 +1,18 @@
 This module assigns cell types to all Neuroblastoma samples in `SCPCP000004`.
 
-Scripts are derived from the the `cell-type-neuroblastoma-04` module of the [OpenScPCA-analysis](https://github.com/AlexsLemonade/OpenScPCA-analysis) repository.
+The module creates a TSV file with annotations for each library with the following columns:
 
+* `barcodes`: Unique cell barcode
+* `neuroblastoma_04_annotation`: Final module cell type annotation
+* `neuroblastoma_04_ontology`: CL ontology id associated with the annotation, if available
+* `neuroblastoma_04_ontology_label`: CL ontology label associated with the annotation, if available
+* `singler_label`: Label predicted by `SingleR`, based on the outputted `pruned.labels` column
+* `scanvi_label`: Label predicted by `scANVI/scArches`, where labels with a posterior probability < 0.75 are given as `Unknown`
+* `cell_class`: Cell classification, one of "tumor", "normal", or "unknown"
+
+For full information about how annotations are assigned, refer to the [`OpenScPCA-analysis` repository's `cell-type-neuroblastoma-04` module README](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/analyses/cell-type-neuroblastoma-04/README.md).
+
+Scripts are derived from the the `cell-type-neuroblastoma-04` module of the [OpenScPCA-analysis](https://github.com/AlexsLemonade/OpenScPCA-analysis) repository.
 Links to specific original scripts and notebooks used in this module:
 
 * `00_convert-nbatlas.R`: <https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/ad3b3c6ac6bcb7154058e4f725250dc56523caa8/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R>

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -290,8 +290,8 @@ workflow cell_type_neuroblastoma_04 {
         assignment_files,
         [ // annotation metadata
           module_name: "cell-type-neuroblastoma-04",
-          annotation_column: "final_label",
-          ontology_column: "final_ontology_id"
+          annotation_column: "neuroblastoma_04_annotation",
+          ontology_column: "neuroblastoma_04_ontology"
         ]
       )}
 

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -193,9 +193,9 @@ process nb_04_assign_celltypes {
       consensus_file=\$(ls ${consensus_files} | grep "\${library_id}")
 
       # output file
-      output_tsv=\${library_id}_neuroblastoma-04_celltype-assignments.tsv
-      assign-celltypes.R \
-        --singler_tsv \${consensus_file} \
+      output_tsv=\${library_id}_neuroblastoma-04_celltype-assignments.tsv.gz
+      assign-labels.R \
+        --singler_tsv \${singler_file} \
         --scanvi_tsv \${scanvi_file} \
         --consensus_tsv \${consensus_file} \
         --nbatlas_label_tsv ${nbatlas_label_file} \
@@ -208,10 +208,10 @@ process nb_04_assign_celltypes {
 
   stub:
     library_ids = singler_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
-    celltype_assignment_output_files = library_ids.collect{"${it}_neuroblastoma-04_celltype-assignments.tsv"}
+    celltype_assignment_output_files = library_ids.collect{"${it}_neuroblastoma-04_celltype-assignments.tsv.gz"}
     """
     for library_id in ${library_ids.join(" ")}; do
-      output_tsv=\${library_id}_neuroblastoma-04_celltype-assignments.tsv
+      output_tsv=\${library_id}_neuroblastoma-04_celltype-assignments.tsv.gz
       touch \${output_tsv}
     done
     """
@@ -270,8 +270,6 @@ workflow cell_type_neuroblastoma_04 {
       // join consensus by sample ID and project ID
       .join(consensus_ch, by: [0, 1]) // sample id, project id, singler, scanvi, consensus, consensus gene exp
       .map { it.dropRight(1) } // we don't need the consensus gene exp file
-
-    assign_ch.view()
 
     // assign final labels
     nb_04_assign_celltypes(

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -166,7 +166,7 @@ process nb_04_assign_celltypes {
   container params.cell_type_nb_04_container
   tag "${sample_id}"
   label 'mem_8'
-  publishDir "${params.results_bucket}/${params.release_prefix}/cell-type-neuroblastoma/${project_id}/${sample_id}", mode: 'copy'
+  publishDir "${params.results_bucket}/${params.release_prefix}/cell-type-neuroblastoma-04/${project_id}/${sample_id}", mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -37,7 +37,7 @@ process nb_04_convert_nbatlas {
 
 process nb_04_train_singler_model {
   container params.cell_type_nb_04_container
-  label 'mem_32'
+  label 'mem_max'
   label 'cpus_4'
   input:
     path nbatlas_sce_file

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -63,7 +63,7 @@ process nb_04_train_singler_model {
 
 process nb_04_train_scanvi_model {
   container params.cell_type_nb_04_container
-  label 'mem_8'
+  label 'mem_16'
   input:
     path nbatlas_anndata_file
   output:

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -177,7 +177,6 @@ process nb_04_assign_celltypes {
     path(nbatlas_ontology_file)
     path(consensus_validation_file)
     val(scanvi_pp_threshold)
-
   output:
     tuple val(sample_id),
           val(project_id),

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/assign-labels.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/assign-labels.R
@@ -237,7 +237,8 @@ final_annotation_df <- annotation_df |>
     neuroblastoma_04_ontology = final_ontology_id,
     neuroblastoma_04_ontology_label = CL_annotation,
     singler_label,
-    scanvi_label
+    scanvi_label,
+    cell_class
   )
 
 

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/assign-labels.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/assign-labels.R
@@ -232,9 +232,9 @@ final_annotation_df <- annotation_df |>
   ) |>
   dplyr::select(
     barcodes,
-    final_label,
-    final_ontology_id,
-    final_cl_ontology_label = CL_annotation,
+    neuroblastoma_04_annotation,
+    neuroblastoma_04_ontology,
+    neuroblastoma_04_ontology_label = CL_annotation,
     singler_label,
     scanvi_label
   )

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/assign-labels.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/assign-labels.R
@@ -1,0 +1,244 @@
+#!/usr/bin/env Rscript
+#
+# This script assigns final annotations to a given neuroblastoma library based on the
+# singler, scanvi/scarches, and consensus annotations.
+# For full information on how these annotations are assigned, please see here:
+# https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/analyses/cell-type-neuroblastoma-04/README.md#annotation-approach
+#
+# This script was adapted from:
+# https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/b2e8e5a042e13a0c1429eb64e1d16c01e1781400/analyses/cell-type-neuroblastoma-04/final-annotation.Rmd
+
+
+library(optparse)
+
+option_list <- list(
+  make_option(
+    opt_str = c("--singler_tsv"),
+    type = "character",
+    default = "",
+    help = "Path to TSV with SingleR annotations for a given library"
+  ),
+  make_option(
+    opt_str = c("--scanvi_tsv"),
+    type = "character",
+    default = "",
+    help = "Path to TSV with scANVI/scArches annotations for a given library"
+  ),
+  make_option(
+    opt_str = c("--consensus_tsv"),
+    type = "character",
+    default = "",
+    help = "Path to TSV with consensus annotations for a given library"
+  ),
+  make_option(
+    opt_str = c("--nbatlas_label_tsv"),
+    type = "character",
+    default = "",
+    help = "Path to TSV mapping NBAtlas labels to their family label"
+  ),
+  make_option(
+    opt_str = c("--nbatlas_ontology_tsv"),
+    type = "character",
+    default = "",
+    help = "Path to TSV mapping NBAtlas labels to ontology ids"
+  ),
+  make_option(
+    opt_str = c("--consensus_validation_tsv"),
+    type = "character",
+    default = "",
+    help = "Path to TSV file with consensus validation groups and ontology ids NBAtlas labels to ontology ids"
+  ),
+  make_option(
+    opt_str = c("--scanvi_posterior_threshold"),
+    type = "numeric",
+    default = 0.75,
+    help = "Posterior probability threshold for labeling cells with scANVI/scArches"
+  ),
+  make_option(
+    opt_str = c("--annotations_tsv"),
+    type = "character",
+    help = "Path to output tsv file with final annotations for a given library"
+  )
+)
+
+
+# Set up --------------------
+
+# Parse options and check arguments
+opts <- parse_args(OptionParser(option_list = option_list))
+
+stopifnot(
+  "singler_tsv does not exist" = file.exists(opts$singler_tsv),
+  "scanvi_tsv does not exist" = file.exists(opts$scanvi_tsv),
+  "consensus_tsv does not exist" = file.exists(opts$consensus_tsv),
+  "nbatlas_label_tsv does not exist" = file.exists(opts$nbatlas_label_tsv),
+  "nbatlas_ontology_tsv does not exist" = file.exists(opts$nbatlas_ontology_tsv),
+  "consensus_validation_tsv does not exist" = file.exists(opts$consensus_validation_tsv),
+  "annotations_tsv must be provided" = !is.null(opts$annotations_tsv),
+  "scanvi_posterior_threshold should be numeric between 0-1" = dplyr::between(opts$scanvi_posterior_threshold, 0, 1)
+)
+
+
+#' Prepare data frame of scANVI or SingleR labels for annotation
+#'
+#' @param df Data frame to prepare
+#' @param annot_type "singler" or "scanvi"
+#' @param ontology_df Data frame of ontology ids
+#' @param label_map_df Data frame mapping labels to family labels
+#'
+#' @returns Wide data frame with ontologies and family labels for the given annotation type
+prep_for_annotation <- function(
+    df,
+    annot_type,
+    ontology_df,
+    label_map_df) {
+  df |>
+    dplyr::rename(label = annot_type) |>
+    ####### Join in the family labels
+    dplyr::left_join(label_map_df, by = c("label" = "NBAtlas_label")) |>
+    dplyr::rename(family = NBAtlas_family) |>
+    ######### Obtain LABEL ontologies
+    dplyr::left_join(ontology_df, by = c("label" = "NBAtlas_label")) |>
+    dplyr::rename(label_ontology = CL_ontology_id) |>
+    ######## Obtain FAMILY ontologies
+    dplyr::left_join(ontology_df, by = c("family" = "NBAtlas_label")) |>
+    dplyr::rename(family_ontology = CL_ontology_id) |>
+    # rename columns to start with `annot_type`
+    dplyr::rename_with(\(x) {
+      paste(annot_type, x, sep = "_")
+    }, -barcodes)
+}
+
+# Define vector of tumor-like cell types to support assigning
+# Neuroendocrine labels
+tumorlike_cells <- c("Schwann", "Stromal other", "Fibroblast")
+
+
+# Read and format cell type data frames -----------------------
+singler_df <- readr::read_tsv(opts$singler_tsv) |>
+  dplyr::mutate(
+    # recode NA -> "Unknown" and NE -> "Neuroendocrine"
+    singler = dplyr::case_when(
+      is.na(pruned.labels) ~ "Unknown",
+      pruned.labels == "NE" ~ "Neuroendocrine",
+      .default = pruned.labels
+    )
+  ) |>
+  dplyr::select(barcodes, singler)
+
+scanvi_df <- readr::read_tsv(opts$scanvi_tsv) |>
+  # pull out barcodes from cell_id
+  tidyr::separate(cell_id, into = c("library_id", "barcodes"), sep = "-") |>
+  # get the posterior for the predicted cell type so we can filter on threshold as needed
+  dplyr::select(
+    barcodes,
+    scanvi = scanvi_prediction,
+    starts_with("pp_")
+  ) |>
+  tidyr::pivot_longer(
+    starts_with("pp_"),
+    names_to = "posterior_celltype",
+    values_to = "posterior"
+  ) |>
+  dplyr::mutate(posterior_celltype = stringr::str_remove(posterior_celltype, "^pp_")) |>
+  dplyr::filter(scanvi == posterior_celltype) |>
+  # recode to Unknown if below the threshold, and NE -> Neuroendocrine
+  dplyr::mutate(scanvi = dplyr::case_when(
+    posterior < opts$scanvi_posterior_threshold ~ "Unknown",
+    scanvi == "NE" ~ "Neuroendocrine",
+    .default = scanvi
+  )) |>
+  dplyr::select(barcodes, scanvi)
+
+
+consensus_df <- readr::read_tsv(opts$consensus_tsv) |>
+  dplyr::select(
+    barcodes,
+    consensus = consensus_annotation,
+    consensus_ontology
+  )
+
+# Read helper data frames -----------------------
+
+label_map_df <- readr::read_tsv(opts$nbatlas_label_tsv)
+ontology_df <- readr::read_tsv(opts$nbatlas_ontology_tsv)
+
+# supports joining on both families and labels without duplicating columns
+ontology_slim_df <- ontology_df |>
+  dplyr::select(-CL_annotation)
+
+validation_df <- readr::read_tsv(opts$consensus_validation_tsv) |>
+  dplyr::rename(
+    consensus = consensus_annotation,
+    consensus_family_label = validation_group_annotation,
+    consensus_family_ontology = validation_group_ontology
+  )
+
+# Prepare data for annotation -----------------------------------------
+singler_annotation_df <- prep_for_annotation(
+  singler_df,
+  "singler",
+  ontology_slim_df,
+  label_map_df
+)
+scanvi_annotation_df <- prep_for_annotation(
+  scanvi_df,
+  "scanvi",
+  ontology_slim_df,
+  label_map_df
+)
+
+annotation_df <- consensus_df |>
+  dplyr::left_join(singler_annotation_df, by = "barcodes") |>
+  dplyr::left_join(scanvi_annotation_df, by = "barcodes") |>
+  dplyr::left_join(validation_df, by = c("consensus", "consensus_ontology")) |>
+  dplyr::select(barcodes, starts_with("consensus"), starts_with("singler"), starts_with("scanvi"))
+
+
+# Assign labels -----------------------------------------
+final_annotation_df <- annotation_df |>
+  dplyr::mutate(
+    # For all comparisons, make sure we aren't comparing NA to NA and getting TRUE
+    final_label = dplyr::case_when(
+      ########### Check for exact match between SingleR/scANVI
+      !is.na(scanvi_label_ontology) & singler_label_ontology == scanvi_label_ontology ~ scanvi_label,
+      ########### Check for family match between SingleR/scANVI
+      !is.na(scanvi_family_ontology) & singler_family_ontology == scanvi_family_ontology ~ scanvi_family,
+      ########## Now use agreement with consensus to assign a label: first by label, and then by family
+      !is.na(consensus_ontology) & singler_label_ontology == consensus_ontology ~ singler_label,
+      !is.na(consensus_ontology) & scanvi_label_ontology == consensus_ontology ~ scanvi_label,
+      !is.na(consensus_family_ontology) & singler_family_ontology == consensus_family_ontology ~ singler_family,
+      !is.na(consensus_family_ontology) & scanvi_family_ontology == consensus_family_ontology ~ scanvi_family,
+      ########## Assign Neuroendocrine where possible; for this step, we refer to NBAtlas labels directly since
+      # the `tumorlike_cells` don't all have ontology ids
+      is.na(consensus_ontology) & singler_label == "Neuroendocrine" & scanvi_label %in% tumorlike_cells ~ "Neuroendocrine",
+      is.na(consensus_ontology) & scanvi_label == "Neuroendocrine" & singler_label %in% tumorlike_cells ~ "Neuroendocrine",
+      # Everything else is Unknown
+      .default = "Unknown"
+    )
+  ) |>
+  # Now, we can bring the final ontologies into the data frame
+  dplyr::inner_join(
+    ontology_df |> dplyr::rename(final_label = NBAtlas_label, final_ontology_id = CL_ontology_id),
+    by = "final_label"
+  ) |>
+  # finalize columns for export
+  dplyr::mutate(
+    cell_class = dplyr::case_when(
+      final_label == "Neuroendocrine" ~ "tumor",
+      final_label == "Unknown" ~ "unknown",
+      .default = "normal"
+    )
+  ) |>
+  dplyr::select(
+    barcodes,
+    final_label,
+    final_ontology_id,
+    final_cl_ontology_label = CL_annotation,
+    singler_label,
+    scanvi_label
+  )
+
+
+# Export to TSV ---------------------------
+readr::write_tsv(final_annotation_df, opts$annotations_tsv)

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/assign-labels.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/assign-labels.R
@@ -11,6 +11,7 @@
 
 library(optparse)
 
+
 option_list <- list(
   make_option(
     opt_str = c("--singler_tsv"),
@@ -49,18 +50,17 @@ option_list <- list(
     help = "Path to TSV file with consensus validation groups and ontology ids NBAtlas labels to ontology ids"
   ),
   make_option(
+    opt_str = c("--annotations_tsv"),
+    type = "character",
+    help = "Path to output tsv file with final annotations for a given library"
+  ),
+  make_option(
     opt_str = c("--scanvi_posterior_threshold"),
     type = "numeric",
     default = 0.75,
     help = "Posterior probability threshold for labeling cells with scANVI/scArches"
-  ),
-  make_option(
-    opt_str = c("--annotations_tsv"),
-    type = "character",
-    help = "Path to output tsv file with final annotations for a given library"
   )
 )
-
 
 # Set up --------------------
 
@@ -230,10 +230,11 @@ final_annotation_df <- annotation_df |>
       .default = "normal"
     )
   ) |>
+  # rename for final export
   dplyr::select(
     barcodes,
-    neuroblastoma_04_annotation,
-    neuroblastoma_04_ontology,
+    neuroblastoma_04_annotation = final_label,
+    neuroblastoma_04_ontology = final_ontology_id,
     neuroblastoma_04_ontology_label = CL_annotation,
     singler_label,
     scanvi_label

--- a/nextflow.config
+++ b/nextflow.config
@@ -113,7 +113,7 @@ profiles {
       results_bucket = "test/stub/results" // no output
       sim_bucket = "test/stub/simulated" // local output
       annotations_bucket = "test/stub/annotations" // local output
-      project = "SCPCP000012" // a small project
+      project = "SCPCP000004,SCPCP000015" // a small project
 
       // Override large reference files for stub testing
       // NBAtlas reference stub

--- a/nextflow.config
+++ b/nextflow.config
@@ -113,7 +113,7 @@ profiles {
       results_bucket = "test/stub/results" // no output
       sim_bucket = "test/stub/simulated" // local output
       annotations_bucket = "test/stub/annotations" // local output
-      project = "SCPCP000004,SCPCP000015" // a small project
+      project = "SCPCP000012" // a small project
 
       // Override large reference files for stub testing
       // NBAtlas reference stub


### PR DESCRIPTION
Stacked on #179
Closes #169 


This PR adds the final process to the `cell-type-neuroblastoma-04` module as well as a couple other small changes:

- I appended `nb_04_` to all the processes I had defined, which seems helpful for future-proofing
- I added the new process `nb_04_assign_celltypes` to run the new script `assign-labels.R` which is based on the annotation notebook. Locally, I ran this to ensure this script produces the same final labels on a couple samples as that notebook in the analysis repo did.
- The workflow now emits cell types along with annotation metadata with expected fields
- I mixed the output in with the ewings output to head into the `export_annotations` workflow

I tested this locally with the `testing` profile, but notably I can't test locally _in Docker_ due to memory limitations, so more testing in batch is forthcoming; will request review once that is set!