### PR TITLE
Account for existing scimilarity results

### DIFF
--- a/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
+++ b/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
@@ -89,6 +89,9 @@ option_list <- list(
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
 
+opt$scimilarity_annotations_file <- "~/Downloads/SCPCL000001_processed_scimilarity-celltype-assignments (1).tsv"
+opt$sce_file <- "~/SCPCL000001_processed.rds"
+
 # Set up -----------------------------------------------------------------------
 
 # make sure input files exist
@@ -200,8 +203,15 @@ join_columns <- c("singler_celltype_ontology", "cellassign_celltype_annotation",
 # by default use the lca between cellassign and singler from the `consensus_ref_file` as the consensus cell type
 consensus_column_prefix <- "cellassign_singler_pair"
 
-# if the library has scimilarity annotations add them in to the coldata
-if (file.exists(opt$scimilarity_annotations_file)) {
+# check if scimilarity already exists
+has_scimilarity <- all(
+  c("scimilarity_celltype_ontology", "scimilarity_celltype_annotation") %in% colnames(celltype_df)
+)
+
+# if the library has scimilarity annotations
+# AND if scimilarity is not already present in the coldata
+# read in results and add them to celltype_df
+if (file.exists(opt$scimilarity_annotations_file) & !has_scimilarity) {
   scimilarity_df <- readr::read_tsv(opt$scimilarity_annotations_file) |>
     dplyr::select(
       barcodes = barcode,
@@ -210,9 +220,16 @@ if (file.exists(opt$scimilarity_annotations_file)) {
       scimilarity_annotation_cl = cl_annotation
     )
 
+  # add scimilarity annotations to celltype_df
   celltype_df <- celltype_df |>
     dplyr::left_join(scimilarity_df, by = "barcodes")
 
+  # reset has scimilarity to be sure we capture the correct join columns below
+  has_scimilarity <- TRUE
+}
+
+# if scimilarity results are present then include them in consensus cell type assignment
+if (has_scimilarity) {
   # if scimilarity exists, include it when joining
   join_columns <- c(join_columns, "scimilarity_celltype_ontology")
 

--- a/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
+++ b/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
@@ -166,6 +166,16 @@ if ("consensus_celltype_annotation" %in% colnames(coldata_df)) {
     )
 }
 
+# rename existing scimilarity cell type columns if they are present
+if ("scimilarity_celltype_annotation" %in% colnames(coldata_df)) {
+  coldata_df <- coldata_df |>
+    # rename old consensus columns to avoid confusion
+    dplyr::rename(
+      existing_scimilarity_celltype_annotation = scimilarity_celltype_annotation,
+      existing_scimilarity_celltype_ontology = scimilarity_celltype_annotation
+    )
+}
+
 # only select sample info and cell type info, we don't need the rest of the coldata
 # if sample is cell line, fill in celltype columns with NA
 if (is_cell_line) {

--- a/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
+++ b/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
@@ -89,9 +89,6 @@ option_list <- list(
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
 
-opt$scimilarity_annotations_file <- "~/Downloads/SCPCL000001_processed_scimilarity-celltype-assignments (1).tsv"
-opt$sce_file <- "~/SCPCL000001_processed.rds"
-
 # Set up -----------------------------------------------------------------------
 
 # make sure input files exist

--- a/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
+++ b/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
@@ -89,6 +89,9 @@ option_list <- list(
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
 
+opt$scimilarity_annotations_file <- "~/Downloads/SCPCL000001_processed_scimilarity-celltype-assignments (1).tsv"
+opt$sce_file <- "~/SCPCL000001_processed.rds"
+
 # Set up -----------------------------------------------------------------------
 
 # make sure input files exist

--- a/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
+++ b/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
@@ -89,9 +89,6 @@ option_list <- list(
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
 
-opt$scimilarity_annotations_file <- "~/Downloads/SCPCL000001_processed_scimilarity-celltype-assignments (1).tsv"
-opt$sce_file <- "~/SCPCL000001_processed.rds"
-
 # Set up -----------------------------------------------------------------------
 
 # make sure input files exist
@@ -203,15 +200,8 @@ join_columns <- c("singler_celltype_ontology", "cellassign_celltype_annotation",
 # by default use the lca between cellassign and singler from the `consensus_ref_file` as the consensus cell type
 consensus_column_prefix <- "cellassign_singler_pair"
 
-# check if scimilarity already exists
-has_scimilarity <- all(
-  c("scimilarity_celltype_ontology", "scimilarity_celltype_annotation") %in% colnames(celltype_df)
-)
-
-# if the library has scimilarity annotations
-# AND if scimilarity is not already present in the coldata
-# read in results and add them to celltype_df
-if (file.exists(opt$scimilarity_annotations_file) & !has_scimilarity) {
+# if the library has scimilarity annotations add them in to the coldata
+if (file.exists(opt$scimilarity_annotations_file)) {
   scimilarity_df <- readr::read_tsv(opt$scimilarity_annotations_file) |>
     dplyr::select(
       barcodes = barcode,
@@ -220,16 +210,9 @@ if (file.exists(opt$scimilarity_annotations_file) & !has_scimilarity) {
       scimilarity_annotation_cl = cl_annotation
     )
 
-  # add scimilarity annotations to celltype_df
   celltype_df <- celltype_df |>
     dplyr::left_join(scimilarity_df, by = "barcodes")
 
-  # reset has scimilarity to be sure we capture the correct join columns below
-  has_scimilarity <- TRUE
-}
-
-# if scimilarity results are present then include them in consensus cell type assignment
-if (has_scimilarity) {
   # if scimilarity exists, include it when joining
   join_columns <- c(join_columns, "scimilarity_celltype_ontology")
 


### PR DESCRIPTION
This fixes the errors seen in https://cloud.seqera.io/orgs/CCDL/workspaces/OpenScPCA/watch/5YRvrcbETGAInN/logs. 

The most recent data release now has existing scimilarity annotations in the objects which was causing a joining error with the scimilarity results in this workflow. I decided that if they are in the object already we should use those results rather than the ones output from the `cell-type-scimilarity` module. Theoretically they should be the same, but I think it makes sense to use what's on the Portal. 

To account for that, I check if they are already present and only add them in if they aren't present. I then made sure we account for the join columns correctly, so I had to split up one of the `if` statements, but I believe this should solve our joining issue. Let me know if you disagree with using the existing annotations and would rather me remove the columns and use the results being output from the module here. 