### PR TITLE
Fix typo in ontology column name

### DIFF
--- a/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
+++ b/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
@@ -172,7 +172,7 @@ if ("scimilarity_celltype_annotation" %in% colnames(coldata_df)) {
     # rename old consensus columns to avoid confusion
     dplyr::rename(
       existing_scimilarity_celltype_annotation = scimilarity_celltype_annotation,
-      existing_scimilarity_celltype_ontology = scimilarity_celltype_annotation
+      existing_scimilarity_celltype_ontology = scimilarity_celltype_ontology
     )
 }
 


### PR DESCRIPTION
Looks like I had a typo in #202 that meant we didn't replace the ontology column like intended. 