### PR TITLE
remove entrypoints and use strict syntax

### DIFF
--- a/.github/workflows/nextflow-checks.yml
+++ b/.github/workflows/nextflow-checks.yml
@@ -36,7 +36,7 @@ jobs:
         run: nextflow -log stub-run.log run main.nf -stub -profile stub -ansi-log false
 
       - name: Check simulate workflow
-        run: nextflow -log simulate-run.log run main.nf -stub -profile stub -ansi-log false -entry simulate
+        run: nextflow -log simulate-run.log run main.nf -stub -profile stub -ansi-log false --workflow simulate
 
       - name: Join log files
         if: ${{ !cancelled() }}

--- a/.github/workflows/nextflow-checks.yml
+++ b/.github/workflows/nextflow-checks.yml
@@ -12,7 +12,7 @@ jobs:
     container: nfcore/tools:3.2.0
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check Nextflow params
         run: nextflow config
@@ -27,24 +27,27 @@ jobs:
     needs: nf-config-check
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Nextflow
-        uses: nf-core/setup-nextflow@v2.0.0
+        uses: nf-core/setup-nextflow@v3.0.0
 
       - name: Check main workflow
         run: nextflow -log stub-run.log run main.nf -stub -profile stub -ansi-log false
 
       - name: Check simulate workflow
-        run: nextflow -log simulate-run.log run main.nf -stub -profile stub -ansi-log false --workflow simulate
+        run: nextflow -log simulate-run.log run main.nf -stub -profile stub -ansi-log
+          false --workflow simulate
 
       - name: Join log files
         if: ${{ !cancelled() }}
-        run: cat stub-run.log simulate-run.log > nextflow-runs.log
+        run: |
+          touch stub-run.log simulate-run.log
+          cat stub-run.log simulate-run.log > nextflow-runs.log
 
       - name: Upload nextflow log
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nextflow-log
           path: nextflow-runs.log

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=200"]
@@ -13,7 +13,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.27.2
+    rev: v8.30.0
     hooks:
       - id: gitleaks
   - repo: local
@@ -28,11 +28,11 @@ repos:
     hooks:
       - id: typos
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.15.12
     hooks:
       - id: ruff-format
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3.9012
+    rev: v0.4.3.9021
     hooks:
       - id: style-files
       - id: parsable-R

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ The workflow also has a couple of entry points other than the main workflow, for
 To run a test version of the workflow to check permissions and infrastructure setup:
 
 ```bash
-nextflow run AlexsLemonade/OpenScPCA-nf -profile batch -entry test
+nextflow run AlexsLemonade/OpenScPCA-nf -profile batch --workflow test
 ```
 
 To run the workflow that creates simulated SCE objects for the OpenScPCA project, you can use the following command, which specifies running the workflow with the `simulate` entry point.
 Note that you will need to specify the directory for the simulation output using the `--sim_pubdir` argument, as the default output bucket is not writeable except by a few specific roles:
 
 ```bash
-nextflow run AlexsLemonade/OpenScPCA-nf -profile batch -entry simulate --sim_pubdir {SIMDIR}
+nextflow run AlexsLemonade/OpenScPCA-nf -profile batch --workflow simulate --sim_pubdir {SIMDIR}
 ```
 
 ### Stub runs

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ To run a test version of the workflow to check permissions and infrastructure se
 nextflow run AlexsLemonade/OpenScPCA-nf -profile batch --workflow test
 ```
 
-To run the workflow that creates simulated SCE objects for the OpenScPCA project, you can use the following command, which specifies running the workflow with the `simulate` entry point.
-Note that you will need to specify the directory for the simulation output using the `--sim_pubdir` argument, as the default output bucket is not writeable except by a few specific roles:
+To run the workflow that creates simulated SCE objects for the OpenScPCA project, you can use the following command, which specifies running the `simulate` workflow.
+Note that you will need to specify the directory for the simulation output using the `--sim_pubdir` argument, as the default output bucket is not writable except by a few specific roles:
 
 ```bash
 nextflow run AlexsLemonade/OpenScPCA-nf -profile batch --workflow simulate --sim_pubdir {SIMDIR}

--- a/main.nf
+++ b/main.nf
@@ -39,31 +39,32 @@ def check_parameters() {
 }
 
 workflow test {
-  check_parameters()
   example()
 }
 
 workflow simulate {
-  check_parameters()
-  def project_ids = params.project?.tokenize(';, ') ?: []
-  def run_all = project_ids.isEmpty() || project_ids[0].toLowerCase() == 'all'
-  def release_dir = Utils.getReleasePath(params.release_bucket, params.release_prefix)
+  take:
+  project_ids
+  run_all
+  release_dir
 
-  project_ch = Channel.fromList(Utils.getProjectTuples(release_dir))
-    .filter{ run_all || it[0] in project_ids }
+  main:
+  project_ch = channel.fromList(Utils.getProjectTuples(release_dir))
+    .filter{ it -> run_all || it[0] in project_ids }
   simulate_sce(project_ch)
 }
 
 // **** Default workflow ****
-workflow {
-  check_parameters()
-  def project_ids = params.project?.tokenize(';, ') ?: []
-  def run_all = project_ids.isEmpty() || project_ids[0].toLowerCase() == 'all'
-  def release_dir = Utils.getReleasePath(params.release_bucket, params.release_prefix)
+workflow openscpca {
+  take:
+  project_ids
+  run_all
+  release_dir
 
+  main:
   // sample channel of [sample_id, project_id, sample_path]
-  sample_ch = Channel.fromList(Utils.getSampleTuples(release_dir))
-    .filter{ run_all || it[1] in project_ids }
+  sample_ch = channel.fromList(Utils.getSampleTuples(release_dir))
+    .filter{ it -> run_all || it[1] in project_ids }
 
 
   // Run the merge workflow
@@ -88,7 +89,7 @@ workflow {
 
   // Run the cell type ewings workflow
   // only runs on SCPCP000015
-  cell_type_ewings(sample_ch.filter{ it[1] == "SCPCP000015" }, cell_type_consensus.out)
+  cell_type_ewings(sample_ch.filter{ it ->it[1] == "SCPCP000015" }, cell_type_consensus.out)
 
   // Run the cell type neuroblastoma 04 workflow
   // only runs on SCPCP000004
@@ -102,4 +103,21 @@ workflow {
   export_ch = cell_type_ewings.out.celltypes
     .mix(cell_type_neuroblastoma_04.out.celltypes)
   export_annotations(export_ch)
+}
+
+// entry workflow
+workflow {
+  check_parameters()
+  def project_ids = params.project?.tokenize(';, ') ?: []
+  def run_all = project_ids.isEmpty() || project_ids[0].toLowerCase() == 'all'
+  def release_dir = Utils.getReleasePath(params.release_bucket, params.release_prefix)
+
+  if (params.workflow == "test") {
+    test()
+  } else if (params.workflow == "simulate") {
+    simulate(project_ids, run_all, release_dir)
+  } else {
+    openscpca(project_ids, run_all, release_dir)
+  }
+
 }

--- a/main.nf
+++ b/main.nf
@@ -93,7 +93,7 @@ workflow openscpca {
 
   // Run the cell type neuroblastoma 04 workflow
   // only runs on SCPCP000004
-  cell_type_neuroblastoma_04(sample_ch.filter{ it[1] == "SCPCP000004" }, cell_type_consensus.out)
+  cell_type_neuroblastoma_04(sample_ch.filter{ it -> it[1] == "SCPCP000004" }, cell_type_consensus.out)
 
   // format and export json files with openscpca annotations
   // input expected to be sample id, project id, tsv files, annotation meta

--- a/modules/cell-type-consensus/main.nf
+++ b/modules/cell-type-consensus/main.nf
@@ -23,7 +23,7 @@ process assign_consensus {
           path("*_processed_consensus-cell-types.tsv.gz"),
           path("*_processed_marker-gene-expression.tsv.gz")
   script:
-    library_ids = library_files.collect{it -> (it.name =~ /SCPCL\d{6}/)[0]}
+    library_ids = library_files.collect{f -> (f.name =~ /SCPCL\d{6}/)[0]}
     """
     for library_id in ${library_ids.join(" ")}; do
       # find files that have the appropriate library id in file name
@@ -50,7 +50,7 @@ process assign_consensus {
     """
 
   stub:
-    library_ids = library_files.collect{it ->(it.name =~ /SCPCL\d{6}/)[0]}
+    library_ids = library_files.collect{f ->(f.name =~ /SCPCL\d{6}/)[0]}
     """
     for library_id in ${library_ids.join(" ")}; do
       touch \${library_id}_processed_consensus-cell-types.tsv.gz

--- a/modules/cell-type-consensus/main.nf
+++ b/modules/cell-type-consensus/main.nf
@@ -23,7 +23,7 @@ process assign_consensus {
           path("*_processed_consensus-cell-types.tsv.gz"),
           path("*_processed_marker-gene-expression.tsv.gz")
   script:
-    library_ids = library_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
+    library_ids = library_files.collect{it -> (it.name =~ /SCPCL\d{6}/)[0]}
     """
     for library_id in ${library_ids.join(" ")}; do
       # find files that have the appropriate library id in file name
@@ -50,7 +50,7 @@ process assign_consensus {
     """
 
   stub:
-    library_ids = library_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
+    library_ids = library_files.collect{it ->(it.name =~ /SCPCL\d{6}/)[0]}
     """
     for library_id in ${library_ids.join(" ")}; do
       touch \${library_id}_processed_consensus-cell-types.tsv.gz

--- a/modules/cell-type-consensus/main.nf
+++ b/modules/cell-type-consensus/main.nf
@@ -6,7 +6,7 @@ process assign_consensus {
   container Utils.pullthroughContainer(params.consensus_cell_type_container, params.pullthrough_registry)
   tag "${sample_id}"
   label 'mem_8'
-  publishDir "${params.results_bucket}/${params.release_prefix}/cell-type-consensus/${project_id}/${sample_id}", mode: 'copy'
+  publishDir { "${params.results_bucket}/${params.release_prefix}/cell-type-consensus/${project_id}/${sample_id}" }, mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),

--- a/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
+++ b/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R
@@ -306,7 +306,6 @@ expressed_markers <- intersect(all_markers, expressed_genes)
 # if no markers are found, fill in columns with NA
 if (length(expressed_markers) == 0) {
   (
-
     gene_exp_df <- data.frame(
       barcodes = rownames(sce),
       library_id = library_id,
@@ -315,7 +314,6 @@ if (length(expressed_markers) == 0) {
       validation_group_annotation = NA,
       validation_group_ontology = NA
     )
-
   )
 } else {
   # get logcounts from sce for expressed genes

--- a/modules/cell-type-ewings/main.nf
+++ b/modules/cell-type-ewings/main.nf
@@ -23,11 +23,11 @@ process ewing_aucell {
           path(mean_exp_output_files)
   script:
     aucell_output_files = library_files
-      .collect{
+      .collect{ it ->
         it.name.replaceAll(/(?i).rds$/, "_ewing-aucell-results.tsv")
       }
     mean_exp_output_files = library_files
-      .collect{
+      .collect{ it ->
         it.name.replaceAll(/(?i).rds$/, "_ewing-geneset-means.tsv")
       }
 
@@ -54,11 +54,11 @@ process ewing_aucell {
 
   stub:
     aucell_output_files = library_files
-      .collect{
+      .collect{ it ->
         it.name.replaceAll(/(?i).rds$/, "_ewing-aucell-results.tsv")
       }
     mean_exp_output_files = library_files
-      .collect{
+      .collect{ it ->
         it.name.replaceAll(/(?i).rds$/, "_ewing-geneset-means.tsv")
       }
     """
@@ -86,8 +86,8 @@ process ewing_assign_celltypes {
           val(project_id),
           path(celltype_assignment_output_files)
   script:
-    library_ids = aucell_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
-    celltype_assignment_output_files = library_ids.collect{"${it}_ewing-celltype-assignments.tsv"}
+    library_ids = aucell_files.collect{it -> (it.name =~ /SCPCL\d{6}/)[0]}
+    celltype_assignment_output_files = library_ids.collect{it -> "${it}_ewing-celltype-assignments.tsv"}
     """
     for library_id in ${library_ids.join(" ")}; do
       # find files that have the appropriate library id in file name
@@ -105,8 +105,8 @@ process ewing_assign_celltypes {
     """
 
   stub:
-    library_ids = aucell_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
-    celltype_assignment_output_files = library_ids.collect{"${it}_ewing-celltype-assignments.tsv"}
+    library_ids = aucell_files.collect{it -> (it.name =~ /SCPCL\d{6}/)[0]}
+    celltype_assignment_output_files = library_ids.collect{it -> "${it}_ewing-celltype-assignments.tsv"}
     """
     for library_id in ${library_ids.join(" ")}; do
       touch \${library_id}_ewing-celltype-assignments.tsv
@@ -142,7 +142,7 @@ workflow cell_type_ewings {
     assign_ch = ewing_aucell.out
       // join by sample ID and project ID
       .join(consensus_ch, by: [0, 1]) // sample id, project id, aucell, mean exp, consensus, consensus gene exp
-      .map { it.dropRight(1) } // we don't need the consensus gene exp file
+      .map { it -> it.dropRight(1) } // we don't need the consensus gene exp file
 
     // assign cell types
     ewing_assign_celltypes(assign_ch, file(params.cell_type_ewings_auc_thresholds_file))

--- a/modules/cell-type-ewings/main.nf
+++ b/modules/cell-type-ewings/main.nf
@@ -23,12 +23,12 @@ process ewing_aucell {
           path(mean_exp_output_files)
   script:
     aucell_output_files = library_files
-      .collect{ it ->
-        it.name.replaceAll(/(?i).rds$/, "_ewing-aucell-results.tsv")
+      .collect{ f ->
+        f.name.replaceAll(/(?i).rds$/, "_ewing-aucell-results.tsv")
       }
     mean_exp_output_files = library_files
-      .collect{ it ->
-        it.name.replaceAll(/(?i).rds$/, "_ewing-geneset-means.tsv")
+      .collect{ f ->
+        f.name.replaceAll(/(?i).rds$/, "_ewing-geneset-means.tsv")
       }
 
     // combine the custom gene sets into a single input
@@ -54,12 +54,12 @@ process ewing_aucell {
 
   stub:
     aucell_output_files = library_files
-      .collect{ it ->
-        it.name.replaceAll(/(?i).rds$/, "_ewing-aucell-results.tsv")
+      .collect{ f ->
+        f.name.replaceAll(/(?i).rds$/, "_ewing-aucell-results.tsv")
       }
     mean_exp_output_files = library_files
-      .collect{ it ->
-        it.name.replaceAll(/(?i).rds$/, "_ewing-geneset-means.tsv")
+      .collect{ f ->
+        f.name.replaceAll(/(?i).rds$/, "_ewing-geneset-means.tsv")
       }
     """
     for file in ${library_files}; do
@@ -86,8 +86,8 @@ process ewing_assign_celltypes {
           val(project_id),
           path(celltype_assignment_output_files)
   script:
-    library_ids = aucell_files.collect{it -> (it.name =~ /SCPCL\d{6}/)[0]}
-    celltype_assignment_output_files = library_ids.collect{it -> "${it}_ewing-celltype-assignments.tsv"}
+    library_ids = aucell_files.collect{ f -> (f.name =~ /SCPCL\d{6}/)[0]}
+    celltype_assignment_output_files = library_ids.collect{ f -> "${f}_ewing-celltype-assignments.tsv"}
     """
     for library_id in ${library_ids.join(" ")}; do
       # find files that have the appropriate library id in file name
@@ -105,8 +105,8 @@ process ewing_assign_celltypes {
     """
 
   stub:
-    library_ids = aucell_files.collect{it -> (it.name =~ /SCPCL\d{6}/)[0]}
-    celltype_assignment_output_files = library_ids.collect{it -> "${it}_ewing-celltype-assignments.tsv"}
+    library_ids = aucell_files.collect{ f -> (f.name =~ /SCPCL\d{6}/)[0]}
+    celltype_assignment_output_files = library_ids.collect{ f -> "${f}_ewing-celltype-assignments.tsv"}
     """
     for library_id in ${library_ids.join(" ")}; do
       touch \${library_id}_ewing-celltype-assignments.tsv

--- a/modules/cell-type-ewings/main.nf
+++ b/modules/cell-type-ewings/main.nf
@@ -6,7 +6,7 @@ process ewing_aucell {
   container Utils.pullthroughContainer(params.cell_type_ewing_container, params.pullthrough_registry)
   tag "${sample_id}"
   label 'mem_8'
-  publishDir "${params.results_bucket}/${params.release_prefix}/cell-type-ewings/${project_id}/${sample_id}", mode: 'copy'
+  publishDir { "${params.results_bucket}/${params.release_prefix}/cell-type-ewings/${project_id}/${sample_id}" }, mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),
@@ -73,7 +73,7 @@ process ewing_assign_celltypes {
   container Utils.pullthroughContainer(params.cell_type_ewing_container, params.pullthrough_registry)
   tag "${sample_id}"
   label 'mem_8'
-  publishDir "${params.results_bucket}/${params.release_prefix}/cell-type-ewings/${project_id}/${sample_id}", mode: 'copy'
+  publishDir { "${params.results_bucket}/${params.release_prefix}/cell-type-ewings/${project_id}/${sample_id}", mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),

--- a/modules/cell-type-ewings/main.nf
+++ b/modules/cell-type-ewings/main.nf
@@ -73,7 +73,7 @@ process ewing_assign_celltypes {
   container Utils.pullthroughContainer(params.cell_type_ewing_container, params.pullthrough_registry)
   tag "${sample_id}"
   label 'mem_8'
-  publishDir { "${params.results_bucket}/${params.release_prefix}/cell-type-ewings/${project_id}/${sample_id}", mode: 'copy'
+  publishDir { "${params.results_bucket}/${params.release_prefix}/cell-type-ewings/${project_id}/${sample_id}" }, mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -182,8 +182,8 @@ process nb_04_assign_celltypes {
           val(project_id),
           path(celltype_assignment_output_files)
   script:
-    library_ids = singler_files.collect{it ->(it.name =~ /SCPCL\d{6}/)[0]}
-    celltype_assignment_output_files = library_ids.collect{ it -> "${it}_neuroblastoma-04_celltype-assignments.tsv.gz"}
+    library_ids = singler_files.collect{ f ->(f.name =~ /SCPCL\d{6}/)[0]}
+    celltype_assignment_output_files = library_ids.collect{ f -> "${f}_neuroblastoma-04_celltype-assignments.tsv.gz"}
     """
     for library_id in ${library_ids.join(" ")}; do
       # find files that have the appropriate library id in file name
@@ -206,8 +206,8 @@ process nb_04_assign_celltypes {
     """
 
   stub:
-    library_ids = singler_files.collect{ it ->(it.name =~ /SCPCL\d{6}/)[0]}
-    celltype_assignment_output_files = library_ids.collect{ it -> "${it}_neuroblastoma-04_celltype-assignments.tsv.gz"}
+    library_ids = singler_files.collect{ f ->(f.name =~ /SCPCL\d{6}/)[0]}
+    celltype_assignment_output_files = library_ids.collect{ f -> "${f}_neuroblastoma-04_celltype-assignments.tsv.gz"}
     """
     for library_id in ${library_ids.join(" ")}; do
       output_tsv=\${library_id}_neuroblastoma-04_celltype-assignments.tsv.gz

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -166,7 +166,7 @@ process nb_04_assign_celltypes {
   container Utils.pullthroughContainer(params.cell_type_nb_04_container, params.pullthrough_registry)
   tag "${sample_id}"
   label 'mem_8'
-  publishDir "${params.results_bucket}/${params.release_prefix}/cell-type-neuroblastoma-04/${project_id}/${sample_id}", mode: 'copy'
+  publishDir { "${params.results_bucket}/${params.release_prefix}/cell-type-neuroblastoma-04/${project_id}/${sample_id}" }, mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),

--- a/modules/cell-type-neuroblastoma-04/main.nf
+++ b/modules/cell-type-neuroblastoma-04/main.nf
@@ -182,8 +182,8 @@ process nb_04_assign_celltypes {
           val(project_id),
           path(celltype_assignment_output_files)
   script:
-    library_ids = singler_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
-    celltype_assignment_output_files = library_ids.collect{"${it}_neuroblastoma-04_celltype-assignments.tsv.gz"}
+    library_ids = singler_files.collect{it ->(it.name =~ /SCPCL\d{6}/)[0]}
+    celltype_assignment_output_files = library_ids.collect{ it -> "${it}_neuroblastoma-04_celltype-assignments.tsv.gz"}
     """
     for library_id in ${library_ids.join(" ")}; do
       # find files that have the appropriate library id in file name
@@ -206,8 +206,8 @@ process nb_04_assign_celltypes {
     """
 
   stub:
-    library_ids = singler_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
-    celltype_assignment_output_files = library_ids.collect{"${it}_neuroblastoma-04_celltype-assignments.tsv.gz"}
+    library_ids = singler_files.collect{ it ->(it.name =~ /SCPCL\d{6}/)[0]}
+    celltype_assignment_output_files = library_ids.collect{ it -> "${it}_neuroblastoma-04_celltype-assignments.tsv.gz"}
     """
     for library_id in ${library_ids.join(" ")}; do
       output_tsv=\${library_id}_neuroblastoma-04_celltype-assignments.tsv.gz
@@ -268,7 +268,7 @@ workflow cell_type_neuroblastoma_04 {
       .join(nb_04_classify_scanvi.out, by: [0, 1]) // sample id, project id, singler, scanvi
       // join consensus by sample ID and project ID
       .join(consensus_ch, by: [0, 1]) // sample id, project id, singler, scanvi, consensus, consensus gene exp
-      .map { it.dropRight(1) } // we don't need the consensus gene exp file
+      .map { it -> it.dropRight(1) } // we don't need the consensus gene exp file
 
     // assign final labels
     nb_04_assign_celltypes(

--- a/modules/cell-type-neuroblastoma-04/resources/usr/bin/assign-labels.R
+++ b/modules/cell-type-neuroblastoma-04/resources/usr/bin/assign-labels.R
@@ -88,10 +88,11 @@ stopifnot(
 #'
 #' @returns Wide data frame with ontologies and family labels for the given annotation type
 prep_for_annotation <- function(
-    df,
-    annot_type,
-    ontology_df,
-    label_map_df) {
+  df,
+  annot_type,
+  ontology_df,
+  label_map_df
+) {
   df |>
     dplyr::rename(label = annot_type) |>
     ####### Join in the family labels

--- a/modules/cell-type-scimilarity/main.nf
+++ b/modules/cell-type-scimilarity/main.nf
@@ -48,7 +48,7 @@ workflow cell_type_scimilarity {
       .map{sample_id, project_id, sample_path ->
         def library_files = Utils.getLibraryFiles(sample_path, format: "anndata", process_level: "processed")
         // filter to only include _rna.h5ad files and remove any _adt.h5ad files
-        library_files = library_files.findAll{ it.name =~ /(?i)_rna.h5ad$/ }
+        library_files = library_files.findAll{ it -> it.name =~ /(?i)_rna.h5ad$/ }
         return [sample_id, project_id, library_files]
       }
       // remove any samples that don't have a processed file

--- a/modules/cell-type-scimilarity/main.nf
+++ b/modules/cell-type-scimilarity/main.nf
@@ -6,7 +6,7 @@ process assign_scimilarity {
   container Utils.pullthroughContainer(params.cell_type_scimilarity_container, params.pullthrough_registry)
   tag "${sample_id}"
   label 'mem_32'
-  publishDir "${params.results_bucket}/${params.release_prefix}/cell-type-scimilarity/${project_id}/${sample_id}", mode: 'copy'
+  publishDir { "${params.results_bucket}/${params.release_prefix}/cell-type-scimilarity/${project_id}/${sample_id}" }, mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),

--- a/modules/doublet-detection/main.nf
+++ b/modules/doublet-detection/main.nf
@@ -17,8 +17,8 @@ process run_scdblfinder {
           path(output_files)
   script:
     output_files = library_files
-      .collect{ it ->
-        it.name.replaceAll(/(?i).rds$/, "_scdblfinder.tsv")
+      .collect{ f ->
+        f.name.replaceAll(/(?i).rds$/, "_scdblfinder.tsv")
       }
     """
     for file in ${library_files}; do
@@ -32,8 +32,8 @@ process run_scdblfinder {
 
   stub:
     output_files = library_files
-      .collect{ it ->
-        it.name.replaceAll(/(?i).rds$/, "_scdblfinder.tsv")
+      .collect{ f ->
+        f.name.replaceAll(/(?i).rds$/, "_scdblfinder.tsv")
       }
     """
     for file in ${library_files}; do

--- a/modules/doublet-detection/main.nf
+++ b/modules/doublet-detection/main.nf
@@ -6,7 +6,7 @@ process run_scdblfinder {
   container Utils.pullthroughContainer(params.doublet_detection_container, params.pullthrough_registry)
   tag "${sample_id}"
   label 'mem_8'
-  publishDir "${params.results_bucket}/${params.release_prefix}/doublet-detection/${project_id}/${sample_id}", mode: 'copy'
+  publishDir { "${params.results_bucket}/${params.release_prefix}/doublet-detection/${project_id}/${sample_id}" }, mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),

--- a/modules/doublet-detection/main.nf
+++ b/modules/doublet-detection/main.nf
@@ -17,7 +17,7 @@ process run_scdblfinder {
           path(output_files)
   script:
     output_files = library_files
-      .collect{
+      .collect{ it ->
         it.name.replaceAll(/(?i).rds$/, "_scdblfinder.tsv")
       }
     """
@@ -32,7 +32,7 @@ process run_scdblfinder {
 
   stub:
     output_files = library_files
-      .collect{
+      .collect{ it ->
         it.name.replaceAll(/(?i).rds$/, "_scdblfinder.tsv")
       }
     """

--- a/modules/example/main.nf
+++ b/modules/example/main.nf
@@ -11,8 +11,8 @@ process say_hello{
 }
 
 workflow example {
-  names_ch = Channel.fromList(["Alex", "World"])
-  say_hello(names_ch).subscribe{
+  names_ch = channel.fromList(["Alex", "World"])
+  say_hello(names_ch).subscribe{ it ->
     log.info(it.getText())
   }
 }

--- a/modules/export-annotations/main.nf
+++ b/modules/export-annotations/main.nf
@@ -6,7 +6,7 @@ process format_annotations {
   container Utils.pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)
   tag "${sample_id}"
   label 'mem_8'
-  publishDir { "${params.annotations_bucket}/${params.release_prefix}/${project_id}/${sample_id}", mode: 'copy'
+  publishDir { "${params.annotations_bucket}/${params.release_prefix}/${project_id}/${sample_id}" }, mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),

--- a/modules/export-annotations/main.nf
+++ b/modules/export-annotations/main.nf
@@ -6,7 +6,7 @@ process format_annotations {
   container Utils.pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)
   tag "${sample_id}"
   label 'mem_8'
-  publishDir "${params.annotations_bucket}/${params.release_prefix}/${project_id}/${sample_id}", mode: 'copy'
+  publishDir { "${params.annotations_bucket}/${params.release_prefix}/${project_id}/${sample_id}", mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),

--- a/modules/export-annotations/main.nf
+++ b/modules/export-annotations/main.nf
@@ -17,7 +17,7 @@ process format_annotations {
           val(project_id),
           path("*_openscpca-annotations.json")
   script:
-    library_ids = annotations_tsv_files.collect{ it -> (it.name =~ /SCPCL\d{6}/)[0]}
+    library_ids = annotations_tsv_files.collect{ f -> (f.name =~ /SCPCL\d{6}/)[0]}
     """
     for library_id in ${library_ids.join(" ")};do
       # get the input files for the library id
@@ -35,7 +35,7 @@ process format_annotations {
     """
 
   stub:
-    library_ids = annotations_tsv_files.collect{ it -> (it.name =~ /SCPCL\d{6}/)[0]}
+    library_ids = annotations_tsv_files.collect{ f -> (f.name =~ /SCPCL\d{6}/)[0]}
     """
     for library_id in ${library_ids.join(" ")};do
       touch \${library_id}_openscpca-annotations.json

--- a/modules/export-annotations/main.nf
+++ b/modules/export-annotations/main.nf
@@ -17,7 +17,7 @@ process format_annotations {
           val(project_id),
           path("*_openscpca-annotations.json")
   script:
-    library_ids = annotations_tsv_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
+    library_ids = annotations_tsv_files.collect{ it -> (it.name =~ /SCPCL\d{6}/)[0]}
     """
     for library_id in ${library_ids.join(" ")};do
       # get the input files for the library id
@@ -35,7 +35,7 @@ process format_annotations {
     """
 
   stub:
-    library_ids = annotations_tsv_files.collect{(it.name =~ /SCPCL\d{6}/)[0]}
+    library_ids = annotations_tsv_files.collect{ it -> (it.name =~ /SCPCL\d{6}/)[0]}
     """
     for library_id in ${library_ids.join(" ")};do
       touch \${library_id}_openscpca-annotations.json

--- a/modules/infercnv-gene-order/main.nf
+++ b/modules/infercnv-gene-order/main.nf
@@ -5,7 +5,7 @@
 process create_gene_order_files {
   container Utils.pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)
   label 'mem_8'
-  publishDir "${params.results_bucket}/${params.release_prefix}/infercnv-gene-order", mode: 'copy'
+  publishDir { "${params.results_bucket}/${params.release_prefix}/infercnv-gene-order" }, mode: 'copy'
   input:
     path gtf_file
     path cytoband_file

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -9,7 +9,7 @@ process merge_group {
   tag "${merge_group_id}"
   label 'mem_max'
   label 'long_running'
-  publishDir "${params.results_bucket}/${params.release_prefix}/merge-sce/${merge_group_id}"
+  publishDir { "${params.results_bucket}/${params.release_prefix}/merge-sce/${merge_group_id}" }
   input:
     tuple val(merge_group_id), val(library_ids), path(processed_files)
   output:
@@ -38,7 +38,7 @@ process merge_group {
 process generate_merge_report {
   container Utils.pullthroughContainer(params.scpcatools_reports_container, params.pullthrough_registry)
   tag "${merge_group_id}"
-  publishDir "${params.results_bucket}/${params.release_prefix}/merge-sce/${merge_group_id}"
+  publishDir { "${params.results_bucket}/${params.release_prefix}/merge-sce/${merge_group_id}" }
   label 'mem_max'
   input:
     tuple val(merge_group_id), path(merged_sce_file)
@@ -70,7 +70,7 @@ process export_anndata {
     label 'mem_max'
     label 'long_running'
     tag "${merge_group_id}"
-    publishDir "${params.results_bucket}/${params.release_prefix}/merge-sce/${merge_group_id}"
+    publishDir { "${params.results_bucket}/${params.release_prefix}/merge-sce/${merge_group_id}" }
     input:
       tuple val(merge_group_id), path(merged_sce_file)
     output:

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -126,7 +126,7 @@ workflow merge_sce {
     libraries_ch = project_branch.single_sample
       .map{ project_id, project_dir ->
         def processed_files = Utils.getLibraryFiles(project_dir, format: "sce", process_level: "processed")
-        def library_ids = processed_files.collect{ it -> it.name.replace('_processed.rds', '')}
+        def library_ids = processed_files.collect{ f -> f.name.replace('_processed.rds', '')}
         return [project_id, library_ids, processed_files]
       }
       .branch{ it ->

--- a/modules/merge-sce/main.nf
+++ b/modules/merge-sce/main.nf
@@ -111,13 +111,13 @@ workflow merge_sce {
 
     // create a channel of [project_id, file(project_dir)] with one per project
     project_ch = sample_ch
-      .map{[it[1], it[2].parent]} // parent of the sample_dir is the project_dir
+      .map{ it -> [it[1], it[2].parent]} // parent of the sample_dir is the project_dir
       .unique()
 
     project_branch = project_ch
-      .branch{
+      .branch{ it ->
         // multiplexed libraries are subdirectories with more than one sample id
-        multiplexed: files(it[1] / "*", type: "dir").any{it.name =~ /SCPCS\d+_SCPCS\d+/}
+        multiplexed: files(it[1] / "*", type: "dir").any{f -> f.name =~ /SCPCS\d+_SCPCS\d+/}
         single_sample: true
       }
 
@@ -126,33 +126,33 @@ workflow merge_sce {
     libraries_ch = project_branch.single_sample
       .map{ project_id, project_dir ->
         def processed_files = Utils.getLibraryFiles(project_dir, format: "sce", process_level: "processed")
-        def library_ids = processed_files.collect{it.name.replace('_processed.rds', '')}
+        def library_ids = processed_files.collect{ it -> it.name.replace('_processed.rds', '')}
         return [project_id, library_ids, processed_files]
       }
-      .branch{
+      .branch{ it ->
         // check the number of libraries
         mergeable: it[1].size() < params.merge_max_libraries
         oversized: true
       }
 
     project_branch.multiplexed
-      .subscribe{
+      .subscribe{ it ->
         log.warn("Not merging ${it[0]} because it contains multiplexed libraries.")
       }
 
     libraries_ch.oversized
-      .subscribe{
+      .subscribe{ it ->
         log.warn("Not merging ${it[0]} because it has too many libraries.")
       }
 
     libraries_branch = libraries_ch.mergeable
-      .branch{
+      .branch{ it ->
         has_merge: params.merge_reuse && file("${publish_merge_base}/${it[0]}/${it[0]}_merged.rds").exists()
         make_merge: true
       }
 
     pre_merged_ch = libraries_branch.has_merge
-      .map{[ // [project id, merged_file] to match the output of merge_group
+      .map{ it -> [ // [project id, merged_file] to match the output of merge_group
         it[0],
         file("${publish_merge_base}/${it[0]}/${it[0]}_merged.rds")
       ]}

--- a/modules/merge-sce/resources/usr/bin/sce_to_anndata.R
+++ b/modules/merge-sce/resources/usr/bin/sce_to_anndata.R
@@ -162,7 +162,6 @@ if (opt$is_merged) {
 message("Formatting done")
 
 
-
 # export sce as anndata object
 # this function will also remove any R-specific object types from the SCE metadata
 #   before converting to AnnData

--- a/modules/seurat-conversion/main.nf
+++ b/modules/seurat-conversion/main.nf
@@ -6,7 +6,7 @@ process seurat_convert {
   container Utils.pullthroughContainer(params.seurat_conversion_container, params.pullthrough_registry)
   tag "${sample_id}"
   label 'mem_8'
-  publishDir "${params.results_bucket}/${params.release_prefix}/seurat-conversion/${project_id}/${sample_id}", mode: 'copy'
+  publishDir { "${params.results_bucket}/${params.release_prefix}/seurat-conversion/${project_id}/${sample_id}" }, mode: 'copy'
   input:
     tuple val(sample_id),
           val(project_id),

--- a/modules/seurat-conversion/main.nf
+++ b/modules/seurat-conversion/main.nf
@@ -17,8 +17,8 @@ process seurat_convert {
           path(output_files)
   script:
     output_files = library_files
-      .collect{ it ->
-        it.name.replaceAll(/(?i).rds$/, "_seurat.rds")
+      .collect{ f ->
+        f.name.replaceAll(/(?i).rds$/, "_seurat.rds")
       }
     """
     # convert all files in the working directory, output to the same directory
@@ -27,8 +27,8 @@ process seurat_convert {
 
   stub:
     output_files = library_files
-      .collect{ it ->
-        it.name.replaceAll(/(?i).rds$/, "_seurat.rds")
+      .collect{ f ->
+        f.name.replaceAll(/(?i).rds$/, "_seurat.rds")
       }
     """
     for file in ${library_files}; do

--- a/modules/seurat-conversion/main.nf
+++ b/modules/seurat-conversion/main.nf
@@ -17,7 +17,7 @@ process seurat_convert {
           path(output_files)
   script:
     output_files = library_files
-      .collect{
+      .collect{ it ->
         it.name.replaceAll(/(?i).rds$/, "_seurat.rds")
       }
     """
@@ -27,7 +27,7 @@ process seurat_convert {
 
   stub:
     output_files = library_files
-      .collect{
+      .collect{ it ->
         it.name.replaceAll(/(?i).rds$/, "_seurat.rds")
       }
     """

--- a/modules/simulate-sce/main.nf
+++ b/modules/simulate-sce/main.nf
@@ -59,7 +59,7 @@ process simulate_sample {
 process export_anndata {
   container Utils.pullthroughContainer(params.scpcatools_anndata_container, params.pullthrough_registry)
   tag "$project_id-$sample_id"
-  publishDir "${params.sim_bucket}/test/${project_id}", mode: 'copy'
+  publishDir { "${params.sim_bucket}/test/${project_id}" }, mode: 'copy'
   input:
     tuple val(project_id),
           val(sample_id),
@@ -86,7 +86,7 @@ process export_anndata {
 process permute_bulk{
   container Utils.pullthroughContainer(params.simulate_sce_container, params.pullthrough_registry)
   tag "$project_id"
-  publishDir "${params.sim_bucket}/test/${project_id}", mode: 'copy'
+  publishDir { "${params.sim_bucket}/test/${project_id}" }, mode: 'copy'
   input:
     tuple val(project_id),
           path(bulk_quant, stageAs: 'input/*'),

--- a/modules/simulate-sce/main.nf
+++ b/modules/simulate-sce/main.nf
@@ -7,7 +7,7 @@
 process permute_metadata {
   container Utils.pullthroughContainer(params.simulate_sce_container, params.pullthrough_registry)
   tag "$project_id"
-  publishDir "${params.sim_bucket}/test/${project_id}", mode: 'copy'
+  publishDir { "${params.sim_bucket}/test/${project_id}" }, mode: 'copy'
   input:
     tuple val(project_id),
           path(metadata_file, stageAs: 'input/*')

--- a/modules/simulate-sce/main.nf
+++ b/modules/simulate-sce/main.nf
@@ -112,19 +112,19 @@ workflow simulate_sce {
     project_ch  // Channel of [project_id, file(project_dir)]
   main:
     // metadata file for each project: [project_id, metadata_file]
-    metadata_ch = project_ch.map{[it[0], it[1] / 'single_cell_metadata.tsv']}
+    metadata_ch = project_ch.map{ it -> [it[0], it[1] / 'single_cell_metadata.tsv']}
     permuted_metadata_ch = permute_metadata(metadata_ch)
 
     // get bulk files for each project, if present: [project_id, bulk_quant_file, bulk_metadata_file]
-    bulk_ch = project_ch.map{[it[0], it[1] / "${it[0]}_bulk_quant.tsv", it[1] / "${it[0]}_bulk_metadata.tsv"]}
-      .filter{it[1].exists()}
+    bulk_ch = project_ch.map{ it -> [it[0], it[1] / "${it[0]}_bulk_quant.tsv", it[1] / "${it[0]}_bulk_metadata.tsv"]}
+      .filter{ it -> it[1].exists()}
     permute_bulk(bulk_ch)
 
     // list rds files for each project and sample: [project_id, [sample_dir1, sample_dir2, ...]]
-    sample_ch = project_ch.map{[it[0], it[1].listFiles().findAll{it.isDirectory()}]}
+    sample_ch = project_ch.map{ it -> [it[0], it[1].listFiles().findAll{f -> f.isDirectory()}]}
       .transpose() // transpose to get a channel of [project_id, sample_dir]
       // get rds file list for each sample: [project_id, sample_id, [rds_file1, rds_file2, ...]]
-      .map{[it[0], it[1].name, it[1].listFiles().findAll{it.name.endsWith(".rds")}]}
+      .map{ it ->  [it[0], it[1].name, it[1].listFiles().findAll{f -> f.name.endsWith(".rds")}]}
       .combine(permuted_metadata_ch, by: 0) // combine with permuted metadata
       // final output: [project_id, sample_id, [rds_file1, rds_file2, ...], permuted_metadata_file]
 

--- a/modules/simulate-sce/resources/usr/bin/sce-to-anndata.R
+++ b/modules/simulate-sce/resources/usr/bin/sce-to-anndata.R
@@ -61,7 +61,6 @@ format_merged_sce <- function(sce) {
 }
 
 
-
 # CZI compliance function ------------------------------------------------------
 
 # this function applies any necessary reformatting or changes needed to make

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,6 +40,8 @@ plugins {
 
 // global default parameters for workflows: output buckets are set to staging by default
 params {
+  // options: default, test, simulate
+  workflow = "default"
   release_prefix = "2026-03-24"
   release_bucket = "s3://openscpca-data-release"
   results_bucket = "s3://openscpca-nf-workflow-results-staging"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -11,6 +11,12 @@
       "description": "",
       "default": "",
       "properties": {
+        "workflow": {
+          "type": "string",
+          "default": "default",
+          "options": ["default", "test", "simulate"],
+          "description": "Workflow to run, either 'default' for the standard workflow, 'test' for a workflow with parameters set for testing, or 'simulate' to run the workflow on simulated data. Default is 'default'."
+        },
         "release_bucket": {
           "type": "string",
           "default": "s3://openscpca-data-release",

--- a/scripts/run_nextflow.sh
+++ b/scripts/run_nextflow.sh
@@ -104,7 +104,7 @@ fi
 if [ "$RUN_MODE" == "test" ]; then
   nextflow run AlexsLemonade/OpenScPCA-nf \
     -revision $GITHUB_TAG \
-    -entry test \
+    --workflow test \
     -profile $profile \
     -with-report "${datetime}_test_report.html" \
     -with-trace  "${datetime}_test_trace.txt" \
@@ -137,7 +137,7 @@ fi
 if [ "$RUN_MODE" == "full" ] || [ "$RUN_MODE" == "simulate-only" ]; then
   nextflow run AlexsLemonade/OpenScPCA-nf \
     -revision $GITHUB_TAG \
-    -entry simulate \
+    --workflow simulate \
     -profile $profile \
     -with-report "${datetime}_simulate_report.html" \
     -with-trace  "${datetime}_simulate_trace.txt" \


### PR DESCRIPTION
Inspired by https://github.com/AlexsLemonade/ews-nf/issues/202, I decided to go ahead and update this workflow for strict syntax. 

The changes I made are to create a new default workflow which calls each of the workflows that were previously used as entrypoints. Now there is a `--workflow` parameter that serves the same function. The main workflow does still handle the parameter validation and intial setup before passing it to the sub-workflows, so now that code isn't duplicated at least. 